### PR TITLE
Wconversion fixes

### DIFF
--- a/src/wobjectdefs.h
+++ b/src/wobjectdefs.h
@@ -43,14 +43,14 @@ template<size_t... I1, size_t... I2>
 index_sequence<I1... , (I2 +(sizeof...(I1)))...>
 make_index_sequence_helper_merge(index_sequence<I1...>, index_sequence<I2...>);
 
-template<int N> struct make_index_sequence_helper {
+template<std::size_t N> struct make_index_sequence_helper {
     using part1 = typename make_index_sequence_helper<(N+1)/2>::result;
     using part2 = typename make_index_sequence_helper<N/2>::result;
     using result = decltype(make_index_sequence_helper_merge(part1(), part2()));
 };
 template<> struct make_index_sequence_helper<1> { using result = index_sequence<0>; };
 template<> struct make_index_sequence_helper<0> { using result = index_sequence<>; };
-template<int N> using make_index_sequence = typename make_index_sequence_helper<N>::result;
+template<std::size_t N> using make_index_sequence = typename make_index_sequence_helper<N>::result;
 
 /* workaround for MSVC bug that can't do decltype(xxx)::foo when xxx is dependent of a template */
 template<typename T> using identity_t = T;
@@ -169,7 +169,7 @@ namespace binary {
     constexpr auto tree_head(tree<void>) { struct _{}; return _{}; }
     template<typename T> constexpr auto tree_head(T) { struct _{}; return _{}; }
 
-    template<int I, typename T> using tree_element_t = decltype(get<I>(std::declval<T>()));
+    template<std::size_t I, typename T> using tree_element_t = decltype(get<I>(std::declval<T>()));
 
     /**
      * tree_cat(tree1, tree2, ....): concatenate trees (like tuple_cat)
@@ -200,18 +200,18 @@ constexpr int summed = sums(Args...);
  */
 
 /** A compile time character array of size N  */
-template<int N> using StaticStringArray = const char [N];
+template<std::size_t N> using StaticStringArray = const char [N];
 
 /** Represents a string of size N  (N includes the '\0' at the end) */
-template<int N, typename = make_index_sequence<N>> struct StaticString;
-template<int N, std::size_t... I> struct StaticString<N, std::index_sequence<I...>>
+template<std::size_t N, typename = make_index_sequence<N>> struct StaticString;
+template<std::size_t N, std::size_t... I> struct StaticString<N, std::index_sequence<I...>>
 {
     StaticStringArray<N> data;
     constexpr StaticString(StaticStringArray<N> &d) : data{ (d[I])... } { }
-    static constexpr int size = N;
+    static constexpr std::size_t size = N;
     constexpr char operator[](int p) const { return data[p]; }
 };
-template <int N> constexpr StaticString<N> makeStaticString(StaticStringArray<N> &d) { return {d}; }
+template <std::size_t N> constexpr StaticString<N> makeStaticString(StaticStringArray<N> &d) { return {d}; }
 
 /** A list containing many StaticString with possibly different sizes */
 template<typename T = void> using StaticStringList = binary::tree<T>;
@@ -221,12 +221,12 @@ constexpr StaticStringList<> makeStaticStringList() { return {}; }
 template<typename... T>
 constexpr StaticStringList<> makeStaticStringList(StaticStringArray<1> &, T...)
 { return {}; }
-template<int N, typename... T>
+template<std::size_t N, typename... T>
 constexpr auto makeStaticStringList(StaticStringArray<N> &h, T&...t)
 { return binary::tree_prepend(makeStaticStringList(t...), StaticString<N>(h)); }
 
 /** Add a string in a StaticStringList */
-template<int L, typename T>
+template<std::size_t L, typename T>
 constexpr auto addString(const StaticStringList<T> &l, const StaticString<L> & s) {
     return binary::tree_append(l, s);
 }
@@ -317,7 +317,7 @@ constexpr std::integral_constant<int, int(w_internal::PropertyFlags::Final)> W_F
 namespace w_internal {
 
 /** Holds information about a method */
-template<typename F, int NameLength, int Flags, typename IC, typename ParamTypes, typename ParamNames = StaticStringList<>>
+template<typename F, std::size_t NameLength, int Flags, typename IC, typename ParamTypes, typename ParamNames = StaticStringList<>>
 struct MetaMethodInfo {
     F func;
     StaticString<NameLength> name;
@@ -329,19 +329,19 @@ struct MetaMethodInfo {
 };
 
 // Called from the W_SLOT macro
-template<typename F, int N, typename ParamTypes, int... Flags, typename IntegralConstant>
+template<typename F, std::size_t N, typename ParamTypes, int... Flags, typename IntegralConstant>
 constexpr MetaMethodInfo<F, N, summed<Flags...> | W_MethodType::Slot.value, IntegralConstant, ParamTypes>
 makeMetaSlotInfo(F f, StaticStringArray<N> &name, IntegralConstant, const ParamTypes &paramTypes, W_MethodFlags<Flags>...)
 { return { f, {name}, paramTypes, {} }; }
 
 // Called from the W_METHOD macro
-template<typename F, int N, typename ParamTypes, int... Flags, typename IntegralConstant>
+template<typename F, std::size_t N, typename ParamTypes, int... Flags, typename IntegralConstant>
 constexpr MetaMethodInfo<F, N, summed<Flags...> | W_MethodType::Method.value, IntegralConstant, ParamTypes>
 makeMetaMethodInfo(F f, StaticStringArray<N> &name, IntegralConstant, const ParamTypes &paramTypes, W_MethodFlags<Flags>...)
 { return { f, {name}, paramTypes, {} }; }
 
 // Called from the W_SIGNAL macro
-template<typename F, int N, typename ParamTypes, typename ParamNames, int... Flags, typename IntegralConstant>
+template<typename F, std::size_t N, typename ParamTypes, typename ParamNames, int... Flags, typename IntegralConstant>
 constexpr MetaMethodInfo<F, N, summed<Flags...> | W_MethodType::Signal.value, IntegralConstant,
                             ParamTypes, ParamNames>
 makeMetaSignalInfo(F f, StaticStringArray<N> &name, IntegralConstant, const ParamTypes &paramTypes,
@@ -349,14 +349,14 @@ makeMetaSignalInfo(F f, StaticStringArray<N> &name, IntegralConstant, const Para
 { return { f, {name}, paramTypes, paramNames }; }
 
 /** Holds information about a constructor */
-template<int NameLength, typename... Args> struct MetaConstructorInfo {
-    static constexpr int argCount = sizeof...(Args);
+template<std::size_t NameLength, typename... Args> struct MetaConstructorInfo {
+    static constexpr std::size_t argCount = sizeof...(Args);
     static constexpr int flags = W_MethodType::Constructor.value | W_Access::Public.value;
     using IntegralConstant = void*; // Used to detect the access specifier, but it is always public, so no need for this
     StaticString<NameLength> name;
-    template<int N>
-    constexpr MetaConstructorInfo<N, Args...> setName(StaticStringArray<N> &name)
-    { return { { name } }; }
+    template<std::size_t N>
+    constexpr MetaConstructorInfo<N, Args...> setName(StaticStringArray<N> &n)
+    { return { { n } }; }
     template<typename T, std::size_t... I>
     void createInstance(void **_a, std::index_sequence<I...>) const {
         *reinterpret_cast<T**>(_a[0]) =
@@ -368,7 +368,7 @@ template<typename...  Args> constexpr MetaConstructorInfo<1,Args...> makeMetaCon
 { return { {""} }; }
 
 /** Holds information about a property */
-template<typename Type, int NameLength, int TypeLength, typename Getter = std::nullptr_t,
+template<typename Type, std::size_t NameLength, std::size_t TypeLength, typename Getter = std::nullptr_t,
             typename Setter = std::nullptr_t, typename Member = std::nullptr_t,
             typename Notify = std::nullptr_t, typename Reset = std::nullptr_t, int Flags = 0>
 struct MetaPropertyInfo {
@@ -463,7 +463,7 @@ template <typename PropInfo, int Flag, typename... Tail>
 constexpr auto parseProperty(const PropInfo &p, std::integral_constant<int, Flag>, Tail... t)
 { return parseProperty(p.template addFlag<Flag>() ,t...); }
 
-template<typename T, int N1, int N2, typename ... Args>
+template<typename T, std::size_t N1, std::size_t N2, typename ... Args>
 constexpr auto makeMetaPropertyInfo(StaticStringArray<N1> &name, StaticStringArray<N2> &type, Args... args) {
     MetaPropertyInfo<T, N1, N2> meta
     { {name}, {type}, {}, {}, {}, {}, {} };
@@ -471,7 +471,7 @@ constexpr auto makeMetaPropertyInfo(StaticStringArray<N1> &name, StaticStringArr
 }
 
 /** Holds information about an enum */
-template<int NameLength, typename Values_, typename Names, int Flags>
+template<std::size_t NameLength, typename Values_, typename Names, int Flags>
 struct MetaEnumInfo {
     StaticString<NameLength> name;
     Names names;
@@ -481,7 +481,7 @@ struct MetaEnumInfo {
 };
 template<typename Enum, Enum... Value> struct enum_sequence {};
 // called from W_ENUM and W_FLAG
-template<typename Enum, int Flag, int NameLength, Enum... Values, typename Names>
+template<typename Enum, int Flag, std::size_t NameLength, Enum... Values, typename Names>
 constexpr MetaEnumInfo<NameLength, std::index_sequence<size_t(Values)...> , Names, Flag> makeMetaEnumInfo(
                 StaticStringArray<NameLength> &name, enum_sequence<Enum, Values...>, Names names) {
     return { {name}, names };

--- a/src/wobjectimpl.h
+++ b/src/wobjectimpl.h
@@ -62,14 +62,14 @@ template<typename Strings, uint... Ints>
 struct IntermediateState {
     Strings strings;
     /// add a string to the strings state and add its index to the end of the int array
-    template<int L>
+    template<std::size_t L>
     constexpr auto addString(const StaticString<L> & s) const {
         auto s2 = binary::tree_append(strings, s);
         return IntermediateState<decltype(s2), Ints..., Strings::size>{s2};
     }
 
     /// same as before but add the IsUnresolvedType flag
-    template<uint Flag = IsUnresolvedType, int L>
+    template<uint Flag = IsUnresolvedType, std::size_t L>
     constexpr auto addTypeString(const StaticString<L> & s) const {
         auto s2 = binary::tree_append(strings, s);
         return IntermediateState<decltype(s2), Ints...,
@@ -169,7 +169,7 @@ static constexpr bool hasNotifySignal(std::index_sequence<I...>)
 }
 
 /** Holds information about a class, including all the properties and methods */
-template<int NameLength, typename Methods, typename Constructors, typename Properties,
+template<std::size_t NameLength, typename Methods, typename Constructors, typename Properties,
             typename Enums, typename ClassInfos, typename Interfaces, int SignalCount>
 struct ObjectInfo {
     StaticString<NameLength> name;
@@ -404,7 +404,7 @@ struct HandleArgsHelper<A, Args...> {
         return HandleArgsHelper<Args...>::result(r1, binary::tree_tail(paramTypes));
     }
 };
-template<int N> struct HandleArgNames {
+template<std::size_t N> struct HandleArgNames {
     template<typename Strings, typename Str>
     static constexpr auto result(const Strings &ss, StaticStringList<Str> pn)
     {
@@ -517,7 +517,7 @@ constexpr auto generateDataArray(const ObjI &objectInfo) {
 /**
  * Holder for the string data.  Just like in the moc generated code.
  */
-template<int N, int L> struct qt_meta_stringdata_t {
+template<std::size_t N, std::size_t L> struct qt_meta_stringdata_t {
      QByteArrayData data[N];
      char stringdata[L];
 };
@@ -696,7 +696,7 @@ static void registerMethodArgumentType(int _id, void **_a) {
         constexpr auto f = binary::get<I>(T::W_MetaObjectCreatorHelper::objectInfo.methods).func;
         using P = QtPrivate::FunctionPointer<std::remove_const_t<decltype(f)>>;
         auto _t = QtPrivate::ConnectionTypes<typename P::Arguments>::types();
-        uint arg = *reinterpret_cast<int*>(_a[1]);
+        uint arg = *reinterpret_cast<uint*>(_a[1]);
         *reinterpret_cast<int*>(_a[0]) = _t && arg < P::ArgumentCount ?
                 _t[arg] : -1;
     }

--- a/src/wobjectimpl.h
+++ b/src/wobjectimpl.h
@@ -245,7 +245,7 @@ struct MethodGenerator {
             // Auto-detect the access specifier
             f |= isPublic<T, M>::value ? W_Access::Public.value : isProtected<T,M>::value ? W_Access::Protected.value : W_Access::Private.value;
         }
-        return f & ~W_Access::Private.value; // Because QMetaMethod::Private is 0, but not W_Access::Private;
+        return f & static_cast<uint>(~W_Access::Private.value); // Because QMetaMethod::Private is 0, but not W_Access::Private;
     }
 };
 


### PR DESCRIPTION
Clang(6.0.0) produces conversion warnings in the changed lines.

also, a shadowed warning was fixed by renaming name to n in line 358