### PR TITLE
Fix multiple-definition linker errors caused by W_NAMESPACE macro

### DIFF
--- a/src/wobjectdefs.h
+++ b/src/wobjectdefs.h
@@ -782,7 +782,7 @@ constexpr auto simple_hash(char const *p) {
         using W_MetaObjectCreatorHelper = NAMESPACE::W_MetaObjectCreatorHelper; \
         static constexpr auto qt_static_metacall = nullptr; \
     }; \
-    constexpr auto &W_UnscopedName = #NAMESPACE; \
+    static constexpr auto &W_UnscopedName = #NAMESPACE; \
     static constexpr w_internal::binary::tree<> w_SlotState(w_internal::w_number<0>, W_ThisType**) { return {}; } \
     static constexpr w_internal::binary::tree<> w_SignalState(w_internal::w_number<0>, W_ThisType**) { return {}; } \
     static constexpr w_internal::binary::tree<> w_MethodState(w_internal::w_number<0>, W_ThisType**) { return {}; } \


### PR DESCRIPTION
C++ doesn't seem to guarantee that a constexpr global variable doesn't take runtime space, and thus might lead to linker errors when included in several compilation units.

I don't see why the variable isn't declared static here, so i propose this simple fix to make it work for us on clang.