### PR TITLE
some cleanups

### DIFF
--- a/src/wobjectdefs.h
+++ b/src/wobjectdefs.h
@@ -380,7 +380,7 @@ template<std::size_t NameLength, typename... Args> struct MetaConstructorInfo {
 };
 // called from the W_CONSTRUCTOR macro
 template<typename...  Args> constexpr MetaConstructorInfo<1,Args...> makeMetaConstructorInfo()
-{ return { {""} }; }
+{ return { {'\0'} }; }
 
 struct Empty{
     constexpr operator bool() const { return false; }
@@ -735,7 +735,7 @@ constexpr auto simple_hash(char const *p) {
         friend constexpr w_internal::binary::tree<> w_EnumState(w_internal::w_number<0>, W_ThisType**) { return {}; } \
         friend constexpr w_internal::binary::tree<> w_ClassInfoState(w_internal::w_number<0>, W_ThisType**) { return {}; } \
         friend constexpr w_internal::binary::tree<> w_InterfaceState(w_internal::w_number<0>, W_ThisType**) { return {}; } \
-        template<typename W_Flag> static inline constexpr w_internal::StaticString<1> w_flagAlias(W_Flag) { return {""}; } \
+        template<typename W_Flag> static inline constexpr w_internal::StaticString<1> w_flagAlias(W_Flag) { return {'\0'}; } \
     public: \
         struct W_MetaObjectCreatorHelper;
 
@@ -803,7 +803,7 @@ constexpr auto simple_hash(char const *p) {
     static constexpr w_internal::binary::tree<> w_EnumState(w_internal::w_number<0>, W_ThisType**) { return {}; } \
     static constexpr w_internal::binary::tree<> w_ClassInfoState(w_internal::w_number<0>, W_ThisType**) { return {}; } \
     static constexpr w_internal::binary::tree<> w_InterfaceState(w_internal::w_number<0>, W_ThisType**) { return {}; } \
-    template<typename W_Flag> static inline constexpr w_internal::StaticString<1> w_flagAlias(W_Flag) { return {""}; } \
+    template<typename W_Flag> static inline constexpr w_internal::StaticString<1> w_flagAlias(W_Flag) { return {'\0'}; } \
     QT_ANNOTATE_CLASS(qt_fake, "")
 
 /**

--- a/src/wobjectdefs.h
+++ b/src/wobjectdefs.h
@@ -184,9 +184,13 @@ namespace binary {
 
 
 /** Compute the sum of many integers */
-constexpr int sums() { return 0; }
+template<typename... Args> constexpr void noOp(Args...) {}
 template<typename... Args>
-constexpr int sums(int i, Args... args) { return i + sums(args...);  }
+constexpr int sums(Args... args) {
+    auto i = int{};
+    noOp((i += args, 0)...);
+    return i;
+}
 // This indirection is required to work around a MSVC bug. (See https://github.com/woboq/verdigris/issues/6 )
 template <int ...Args>
 constexpr int summed = sums(Args...);

--- a/src/wobjectdefs.h
+++ b/src/wobjectdefs.h
@@ -188,11 +188,11 @@ namespace binary {
 
 
 /** Compute the sum of many integers */
-template<typename... Args> constexpr void noOp(Args...) {}
+template<typename T> constexpr void ordered(std::initializer_list<T>) {}
 template<typename... Args>
 constexpr int sums(Args... args) {
     auto i = int{};
-    noOp((i += args, 0)...);
+    ordered<int>({(i += args, 0)...});
     return i;
 }
 // This indirection is required to work around a MSVC bug. (See https://github.com/woboq/verdigris/issues/6 )

--- a/src/wobjectdefs.h
+++ b/src/wobjectdefs.h
@@ -33,6 +33,7 @@
 namespace w_internal {
 using std::index_sequence;  // From C++14, make sure to enable the C++14 option in your compiler
 
+#ifdef W_USE_CUSTOM_MAKE_INDEX_SEQUENCE
 /* The default std::make_index_sequence from libstdc++ is recursing O(N) times which is reaching
     recursion limits level for big strings. This implementation has only O(log N) recursion */
 template<size_t... I1, size_t... I2>
@@ -47,6 +48,9 @@ template<std::size_t N> struct make_index_sequence_helper {
 template<> struct make_index_sequence_helper<1> { using result = index_sequence<0>; };
 template<> struct make_index_sequence_helper<0> { using result = index_sequence<>; };
 template<std::size_t N> using make_index_sequence = typename make_index_sequence_helper<N>::result;
+#else
+using std::make_index_sequence;
+#endif
 
 /* workaround for MSVC bug that can't do decltype(xxx)::foo when xxx is dependent of a template */
 template<typename T> using identity_t = T;

--- a/src/wobjectimpl.h
+++ b/src/wobjectimpl.h
@@ -510,7 +510,7 @@ constexpr auto generateDataArray(const ObjI &objectInfo) {
     constexpr int enumValueOffset = constructorParamIndex +
         paramOffset<decltype(objectInfo.constructors)>(make_index_sequence<ObjI::constructorCount>{});
 
-    auto stringData = binary::tree_append(binary::tree_append(binary::tree<>{} , objectInfo.name), StaticString<1>{0});
+    auto stringData = binary::tree_append(binary::tree_append(binary::tree<>{} , objectInfo.name), StaticString<1>{'\0'});
     IntermediateState<decltype(stringData),
             QT_VERSION >= QT_VERSION_CHECK(5, 12, 0) ? 8 : 7, // revision
             0,       // classname

--- a/src/wobjectimpl.h
+++ b/src/wobjectimpl.h
@@ -35,10 +35,10 @@ template<std::size_t... I1, std::size_t... I2> struct concatenate_helper<std::in
     static constexpr int size = sizeof...(I1) + sizeof...(I2);
     static constexpr auto concatenate(const StaticString<sizeof...(I1)> &s1, const StaticString<sizeof...(I2)> &s2) {
         StaticStringArray<size> d = { s1[I1]... , s2[I2]... };
-        return StaticString<size>( d );
+        return makeStaticString(d);
     }
 };
-constexpr StaticString<1> concatenate(StaticStringList<>) { return {""}; }
+constexpr StaticString<1> concatenate(StaticStringList<>) { return {0}; }
 template<typename T> constexpr auto concatenate(StaticStringList<binary::Leaf<T>> s) { return s.root.data; }
 template<typename A, typename B> constexpr auto concatenate(StaticStringList<binary::Node<A,B>> s) {
     auto a = concatenate(binary::tree<A>{s.root.a});
@@ -207,7 +207,7 @@ static constexpr auto makeObjectInfo(StaticStringArray<N> &name) {
     constexpr int sigCount = sigState.size;
     return ObjectInfo<N, decltype(methodInfo), decltype(constructorInfo), decltype(propertyInfo),
                         decltype(enumInfo), decltype(classInfo), decltype(interfaceInfo), sigCount>
-        { {name}, methodInfo, constructorInfo, propertyInfo, enumInfo, classInfo, interfaceInfo };
+        { makeStaticString(name), methodInfo, constructorInfo, propertyInfo, enumInfo, classInfo, interfaceInfo };
 }
 
 // Generator for Q_CLASSINFO to be used in generate<>()
@@ -510,7 +510,7 @@ constexpr auto generateDataArray(const ObjI &objectInfo) {
     constexpr int enumValueOffset = constructorParamIndex +
         paramOffset<decltype(objectInfo.constructors)>(make_index_sequence<ObjI::constructorCount>{});
 
-    auto stringData = binary::tree_append(binary::tree_append(binary::tree<>{} , objectInfo.name), StaticString<1>(""));
+    auto stringData = binary::tree_append(binary::tree_append(binary::tree<>{} , objectInfo.name), StaticString<1>{0});
     IntermediateState<decltype(stringData),
             QT_VERSION >= QT_VERSION_CHECK(5, 12, 0) ? 8 : 7, // revision
             0,       // classname

--- a/src/wobjectimpl.h
+++ b/src/wobjectimpl.h
@@ -38,7 +38,7 @@ template<std::size_t... I1, std::size_t... I2> struct concatenate_helper<std::in
         return makeStaticString(d);
     }
 };
-constexpr StaticString<1> concatenate(StaticStringList<>) { return {0}; }
+constexpr StaticString<1> concatenate(StaticStringList<>) { return {'\0'}; }
 template<typename T> constexpr auto concatenate(StaticStringList<binary::Leaf<T>> s) { return s.root.data; }
 template<typename A, typename B> constexpr auto concatenate(StaticStringList<binary::Node<A,B>> s) {
     auto a = concatenate(binary::tree<A>{s.root.a});


### PR DESCRIPTION
1. `std::make_index_sequence` should be faster than any hand written code on most compilers. It can and should use intrinsics.
2. sums can be implemented without recursion.
3. There is no need for the StaticString type to carry the index_sequence in the name. Also the constructor is not necessary (rule of 0) - same as std::array.