### PR TITLE
PoC: Specialized Tuple instead of binary::tree

### DIFF
--- a/src/wobjectdefs.h
+++ b/src/wobjectdefs.h
@@ -380,7 +380,7 @@ template<std::size_t NameLength, typename... Args> struct MetaConstructorInfo {
 };
 // called from the W_CONSTRUCTOR macro
 template<typename...  Args> constexpr MetaConstructorInfo<1,Args...> makeMetaConstructorInfo()
-{ return { {""} }; }
+{ return { {'\0'} }; }
 
 struct Empty{
     constexpr operator bool() const { return false; }
@@ -735,7 +735,7 @@ constexpr auto simple_hash(char const *p) {
         friend constexpr w_internal::binary::tree<> w_EnumState(w_internal::w_number<0>, W_ThisType**) { return {}; } \
         friend constexpr w_internal::binary::tree<> w_ClassInfoState(w_internal::w_number<0>, W_ThisType**) { return {}; } \
         friend constexpr w_internal::binary::tree<> w_InterfaceState(w_internal::w_number<0>, W_ThisType**) { return {}; } \
-        template<typename W_Flag> static inline constexpr w_internal::StaticString<1> w_flagAlias(W_Flag) { return {""}; } \
+        template<typename W_Flag> static inline constexpr w_internal::StaticString<1> w_flagAlias(W_Flag) { return {'\0'}; } \
     public: \
         struct W_MetaObjectCreatorHelper;
 
@@ -803,7 +803,7 @@ constexpr auto simple_hash(char const *p) {
     static constexpr w_internal::binary::tree<> w_EnumState(w_internal::w_number<0>, W_ThisType**) { return {}; } \
     static constexpr w_internal::binary::tree<> w_ClassInfoState(w_internal::w_number<0>, W_ThisType**) { return {}; } \
     static constexpr w_internal::binary::tree<> w_InterfaceState(w_internal::w_number<0>, W_ThisType**) { return {}; } \
-    template<typename W_Flag> static inline constexpr w_internal::StaticString<1> w_flagAlias(W_Flag) { return {""}; } \
+    template<typename W_Flag> static inline constexpr w_internal::StaticString<1> w_flagAlias(W_Flag) { return {'\0'}; } \
     QT_ANNOTATE_CLASS(qt_fake, "")
 
 /**

--- a/src/wobjectdefs.h
+++ b/src/wobjectdefs.h
@@ -320,13 +320,15 @@ template<size_t Offset = 1000, size_t... Ls>
 using StaticStringList = constple::Tuple<TypePack<StaticString<Ls>...>, Offset>;
 
 /** Make a StaticStringList out of many char array  */
-constexpr StaticStringList<> makeStaticStringList() { return {}; }
+constexpr StaticStringList<> makeStaticLiteralList() { return {}; }
 template<typename... T>
-constexpr StaticStringList<> makeStaticStringList(StaticStringArray<1> &, T...)
+constexpr StaticStringList<> makeStaticLiteralList(StaticStringArray<1> &, T...)
 { return {}; }
 template<std::size_t N, typename... T>
-constexpr auto makeStaticStringList(StaticStringArray<N> &h, T&...t)
-{ return makeStaticStringList(t...).prepend(makeStaticString(h)); }
+constexpr auto makeStaticLiteralList(StaticStringArray<N> &h, T&...t)
+{ return makeStaticLiteralList(t...).prepend(makeStaticString(h)); }
+
+constexpr StaticStringList<> makeStaticStringList() { return {}; }
 template<typename... T>
 constexpr StaticStringList<> makeStaticStringList(StaticString<1>, T...)
 { return {}; }
@@ -334,9 +336,9 @@ template<std::size_t N, typename... T>
 constexpr auto makeStaticStringList(StaticString<N> h, T...t)
 { return makeStaticStringList(t...).prepend(h); }
 
-static_assert(std::is_same<decltype(makeStaticStringList()), StaticStringList<>>::value, "");
-static_assert(std::is_same<decltype(makeStaticStringList("H", "el"))::Pack, TypePack<StaticString<2>, StaticString<3>>>::value, "");
-static_assert(std::is_same<decltype(makeStaticStringList("H", "", "el"))::Pack, TypePack<StaticString<2>>>::value, "");
+static_assert(std::is_same<decltype(makeStaticLiteralList()), StaticStringList<>>::value, "");
+static_assert(std::is_same<decltype(makeStaticLiteralList("H", "el"))::Pack, TypePack<StaticString<2>, StaticString<3>>>::value, "");
+static_assert(std::is_same<decltype(makeStaticLiteralList("H", "", "el"))::Pack, TypePack<StaticString<2>>>::value, "");
 
 /*-----------*/
 
@@ -757,7 +759,7 @@ template <typename... Args> constexpr QOverload<Args...> qOverload = {};
 // strignify and make a StaticStringList out of an array of arguments
 #define W_PARAM_TOSTRING(...) W_MACRO_MSVC_EMPTY W_MACRO_MSVC_DELAY(W_PARAM_TOSTRING2,__VA_ARGS__ ,,,,,,,,,,,,,,,,)
 #define W_PARAM_TOSTRING2(A1,A2,A3,A4,A5,A6,A7,A8,A9,A10,A11,A12,A13,A14,A15,A16,...) \
-    w_internal::makeStaticStringList(#A1,#A2,#A3,#A4,#A5,#A6,#A7,#A8,#A9,#A10,#A11,#A12,#A13,#A14,#A15,#A16)
+    w_internal::makeStaticLiteralList(#A1,#A2,#A3,#A4,#A5,#A6,#A7,#A8,#A9,#A10,#A11,#A12,#A13,#A14,#A15,#A16)
 
 #define W_PARAM_TOSTRING_REMOVE_SCOPE(...) W_MACRO_MSVC_EMPTY W_MACRO_MSVC_DELAY(W_PARAM_TOSTRING2_REMOVE_SCOPE,__VA_ARGS__ ,,,,,,,,,,,,,,,,)
 #define W_PARAM_TOSTRING2_REMOVE_SCOPE(A1,A2,A3,A4,A5,A6,A7,A8,A9,A10,A11,A12,A13,A14,A15,A16,...) \

--- a/src/wobjectdefs.h
+++ b/src/wobjectdefs.h
@@ -101,6 +101,8 @@ struct TupleImpl<TypePack<Ts...>, Offset, index_sequence<Is...>>
     static constexpr auto size = sizeof...(Ts);
     static_assert (size == sizeof... (Is), "Index has wrong length");
 
+    constexpr TupleImpl() = default;
+
     template<class... Us
               , class = std::enable_if_t< sizeof...( Us ) == sizeof...( Ts ) >
 #ifndef Q_CC_GNU // Gcc seems to fail on this

--- a/src/wobjectdefs.h
+++ b/src/wobjectdefs.h
@@ -302,7 +302,7 @@ template<std::size_t N> using StaticStringArray = const char [N];
 /** Represents a string of size N  (N includes the '\0' at the end) */
 template<std::size_t N> struct StaticString
 {
-    StaticStringArray<N> data = {};
+    char data[N] = {};
     static constexpr std::size_t size = N;
     constexpr char operator[](int p) const { return data[p]; }
 };

--- a/src/wobjectdefs.h
+++ b/src/wobjectdefs.h
@@ -620,11 +620,11 @@ template<int N> constexpr int removedScopeSize(StaticStringArray<N> &name) {
 }
 
 template<int R, int N> constexpr StaticString<R> removeScope(StaticStringArray<N> &name) {
-    char result[R] = {};
+    StaticString<R> r;
     for (int i = 0; i < R; ++i) {
-        result[i] = name[N - R + i];
+        r.data[i] = name[N - R + i];
     }
-    return makeStaticString(result);
+    return r;
 }
 
 // STRing REMove SCOPE:  strignify while removing the scope

--- a/src/wobjectdefs.h
+++ b/src/wobjectdefs.h
@@ -325,26 +325,16 @@ constexpr StaticStringList<> makeStaticStringList(StaticStringArray<1> &, T...)
 template<std::size_t N, typename... T>
 constexpr auto makeStaticStringList(StaticStringArray<N> &h, T&...t)
 { return makeStaticStringList(t...).prepend(makeStaticString(h)); }
-// { return binary::tree_prepend(makeStaticStringList(t...), makeStaticString(h)); }
 template<typename... T>
 constexpr StaticStringList<> makeStaticStringList(StaticString<1>, T...)
 { return {}; }
 template<std::size_t N, typename... T>
 constexpr auto makeStaticStringList(StaticString<N> h, T...t)
 { return makeStaticStringList(t...).prepend(h); }
-//{ return binary::tree_prepend(makeStaticStringList(t...), h); }
 
 static_assert(std::is_same<decltype(makeStaticStringList()), StaticStringList<>>::value, "");
 static_assert(std::is_same<decltype(makeStaticStringList("H", "el"))::Pack, TypePack<StaticString<2>, StaticString<3>>>::value, "");
 static_assert(std::is_same<decltype(makeStaticStringList("H", "", "el"))::Pack, TypePack<StaticString<2>>>::value, "");
-
-/** Add a string in a StaticStringList */
-template<std::size_t L, size_t Offset, size_t... Ls>
-constexpr auto addString(const StaticStringList<Offset, Ls...> &l, const StaticString<L> & s) {
-    return l.append(s);
-    //return binary::tree_append(l, s);
-}
-
 
 /*-----------*/
 

--- a/src/wobjectdefs.h
+++ b/src/wobjectdefs.h
@@ -184,9 +184,13 @@ namespace binary {
 
 
 /** Compute the sum of many integers */
-constexpr int sums() { return 0; }
+template<typename... Args> constexpr void noOp(Args...) {}
 template<typename... Args>
-constexpr int sums(int i, Args... args) { return i + sums(args...);  }
+constexpr int sums(Args... args) {
+    auto i = int{};
+    noOp((i += args, 0)...);
+    return i;
+}
 // This indirection is required to work around a MSVC bug. (See https://github.com/woboq/verdigris/issues/6 )
 template <int ...Args>
 constexpr int summed = sums(Args...);

--- a/src/wobjectdefs.h
+++ b/src/wobjectdefs.h
@@ -57,13 +57,14 @@ template<typename T> using identity_t = T;
 
 template<typename T> constexpr void ordered(std::initializer_list<T>) {}
 
-namespace constple {
-
 template <class...> struct TypePack {};
 template <size_t> struct Index {};
+template <size_t I> constexpr auto index = Index<I>{};
 
 template<class... Ts>
 constexpr auto typeCount(TypePack<Ts...>) -> size_t { return sizeof... (Ts); }
+
+namespace constple {
 
 template <class T, size_t I>
 struct Indexed {
@@ -315,7 +316,6 @@ template <std::size_t N> constexpr StaticString<N> makeStaticString(StaticString
 }
 
 /** A list containing many StaticString with possibly different sizes */
-using constple::TypePack;
 template<size_t Offset = 1000, size_t... Ls>
 using StaticStringList = constple::Tuple<TypePack<StaticString<Ls>...>, Offset>;
 

--- a/src/wobjectdefs.h
+++ b/src/wobjectdefs.h
@@ -301,18 +301,15 @@ constexpr int summed = sums(Args...);
 template<std::size_t N> using StaticStringArray = const char [N];
 
 /** Represents a string of size N  (N includes the '\0' at the end) */
-template<std::size_t N> struct StaticString
-{
+template<std::size_t N> struct StaticString {
     char data[N] = {};
     static constexpr std::size_t size = N;
     constexpr char operator[](int p) const { return data[p]; }
 };
-template <std::size_t N, std::size_t... Is>
-constexpr StaticString<N> makeStaticString(StaticStringArray<N> &d, index_sequence<Is...>) {
-    return { {d[Is]...} };
-}
 template <std::size_t N> constexpr StaticString<N> makeStaticString(StaticStringArray<N> &d) {
-    return makeStaticString(d, make_index_sequence<N>{});
+    auto r = StaticString<N>{};
+    for (auto i = 0u; i < N; ++i) r.data[i] = d[i];
+    return r;
 }
 
 /** A list containing many StaticString with possibly different sizes */

--- a/src/wobjectdefs.h
+++ b/src/wobjectdefs.h
@@ -188,11 +188,11 @@ namespace binary {
 
 
 /** Compute the sum of many integers */
-template<typename... Args> constexpr void noOp(Args...) {}
+template<typename T> constexpr void ordered(std::initializer_list<T>) {}
 template<typename... Args>
 constexpr int sums(Args... args) {
     auto i = int{};
-    noOp((i += args, 0)...);
+    ordered<int>({(i += args, 0)...});
     return i;
 }
 // This indirection is required to work around a MSVC bug. (See https://github.com/woboq/verdigris/issues/6 )

--- a/src/wobjectdefs.h
+++ b/src/wobjectdefs.h
@@ -33,6 +33,7 @@
 namespace w_internal {
 using std::index_sequence;  // From C++14, make sure to enable the C++14 option in your compiler
 
+#ifdef W_USE_CUSTOM_MAKE_INDEX_SEQUENCE
 /* The default std::make_index_sequence from libstdc++ is recursing O(N) times which is reaching
     recursion limits level for big strings. This implementation has only O(log N) recursion */
 template<size_t... I1, size_t... I2>
@@ -47,6 +48,9 @@ template<std::size_t N> struct make_index_sequence_helper {
 template<> struct make_index_sequence_helper<1> { using result = index_sequence<0>; };
 template<> struct make_index_sequence_helper<0> { using result = index_sequence<>; };
 template<std::size_t N> using make_index_sequence = typename make_index_sequence_helper<N>::result;
+#else
+using std::make_index_sequence;
+#endif
 
 /* workaround for MSVC bug that can't do decltype(xxx)::foo when xxx is dependent of a template */
 template<typename T> using identity_t = T;

--- a/src/wobjectimpl.h
+++ b/src/wobjectimpl.h
@@ -385,13 +385,13 @@ struct EnumGenerator {
 // Generator for enum values
 struct EnumValuesGenerator {
     template<typename Strings, typename Names, size_t I = 0>
-    static constexpr auto generateSingleEnumValues(const Strings &s, std::index_sequence<>, const Names&, constple::Index<I> = {})
+    static constexpr auto generateSingleEnumValues(const Strings &s, std::index_sequence<>, const Names&, Index<I> = {})
     { return s; }
 
     template<typename Strings, std::size_t Value, std::size_t... Vs, typename Names, size_t I = 0>
-    static constexpr auto generateSingleEnumValues(const Strings &s, std::index_sequence<Value, Vs...>, const Names& names, constple::Index<I> = {}) {
+    static constexpr auto generateSingleEnumValues(const Strings &s, std::index_sequence<Value, Vs...>, const Names& names, Index<I> = {}) {
         auto s2 = s.addString(constple::get<I>(names)).template add<uint(Value)>();
-        return generateSingleEnumValues(s2, std::index_sequence<Vs...>{}, names, constple::Index<I+1>{});
+        return generateSingleEnumValues(s2, std::index_sequence<Vs...>{}, names, index<I+1>);
     }
 
     template<typename> static constexpr int offset() { return 0; }
@@ -407,35 +407,35 @@ struct EnumValuesGenerator {
  */
 template<typename ...Args> struct HandleArgsHelper {
     template<typename Strings, typename ParamTypes, size_t I = 0>
-    static constexpr auto result(const Strings &ss, const ParamTypes&, constple::Index<I> = {})
+    static constexpr auto result(const Strings &ss, const ParamTypes&, Index<I> = {})
     { return ss; }
 };
 template<typename A, typename... Args>
 struct HandleArgsHelper<A, Args...> {
     template<typename Strings, typename ParamTypes, size_t I = 0>
-    static constexpr auto result(const Strings &ss, const ParamTypes &paramTypes, constple::Index<I> = {}) {
+    static constexpr auto result(const Strings &ss, const ParamTypes &paramTypes, Index<I> = {}) {
         using Type = typename QtPrivate::RemoveConstRef<A>::Type;
         auto typeStr = constple::fetch<I>(paramTypes);
         using ts_t = decltype(typeStr);
         // This way, the overload of result will not pick the StaticString one if it is a tuple (because registered types have the priority)
         auto typeStr2 = std::conditional_t<std::is_same<A, Type>::value, ts_t, std::tuple<ts_t>>{typeStr};
         auto r1 = HandleType<Type>::result(ss, typeStr2);
-        return HandleArgsHelper<Args...>::result(r1, paramTypes, constple::Index<I+1>{});
+        return HandleArgsHelper<Args...>::result(r1, paramTypes, index<I+1>);
     }
 };
 template<std::size_t N> struct HandleArgNames {
     template<typename Strings, size_t Offset, size_t... Ls, size_t I = 0>
-    static constexpr auto result(const Strings &ss, const StaticStringList<Offset, Ls...>& pn, constple::Index<I> = {}, std::enable_if_t<(I < sizeof... (Ls))>* = {}) {
+    static constexpr auto result(const Strings &ss, const StaticStringList<Offset, Ls...>& pn, Index<I> = {}, std::enable_if_t<(I < sizeof... (Ls))>* = {}) {
         auto s2 = ss.addString(constple::get<I>(pn));
-        return HandleArgNames<N-1>::result(s2, pn, constple::Index<I+1>{});
+        return HandleArgNames<N-1>::result(s2, pn, index<I+1>);
     }
     template<typename Strings, size_t Offset, size_t...Ls, size_t I = 0>
-    static constexpr auto result(const Strings &ss, const StaticStringList<Offset, Ls...>& pn, constple::Index<I> = {}, std::enable_if_t<(I >= sizeof... (Ls))>* = {})
-    { return HandleArgNames<N-1>::result(ss.template add<1>(), pn, constple::Index<I+1>{}); }
+    static constexpr auto result(const Strings &ss, const StaticStringList<Offset, Ls...>& pn, Index<I> = {}, std::enable_if_t<(I >= sizeof... (Ls))>* = {})
+    { return HandleArgNames<N-1>::result(ss.template add<1>(), pn, index<I+1>); }
 };
 template<> struct HandleArgNames<0> {
     template<typename Strings, typename PN, size_t I = 0>
-    static constexpr auto result(const Strings &ss, const PN&, constple::Index<I> = {})
+    static constexpr auto result(const Strings &ss, const PN&, Index<I> = {})
     { return ss; }
 };
 

--- a/src/wobjectimpl.h
+++ b/src/wobjectimpl.h
@@ -38,7 +38,7 @@ constexpr auto store(char*& p, const T& s) {
 template<size_t ... Ls, size_t Offset, size_t... Is>
 constexpr auto concatenate(const constple::TupleImpl<TypePack<StaticString<Ls>...>, Offset, index_sequence<Is...>>& ssl) {
     StaticString<summed<Ls...>> r;
-    auto p = const_cast<char*>(r.data);
+    auto p = r.data;
     ordered<int>({store(p, constple::getImpl<Is>(ssl))...});
     return r;
 }

--- a/src/wobjectimpl.h
+++ b/src/wobjectimpl.h
@@ -510,7 +510,7 @@ constexpr auto generateDataArray(const ObjI &objectInfo) {
     constexpr int enumValueOffset = constructorParamIndex +
         paramOffset<decltype(objectInfo.constructors)>(make_index_sequence<ObjI::constructorCount>{});
 
-    auto stringData = binary::tree_append(binary::tree_append(binary::tree<>{} , objectInfo.name), StaticString<1>{0});
+    auto stringData = binary::tree_append(binary::tree_append(binary::tree<>{} , objectInfo.name), StaticString<1>{'\0'});
     IntermediateState<decltype(stringData),
             QT_VERSION >= QT_VERSION_CHECK(5, 12, 0) ? 8 : 7, // revision
             0,       // classname

--- a/src/wobjectimpl.h
+++ b/src/wobjectimpl.h
@@ -30,21 +30,11 @@ namespace w_internal {
  * Returns a StaticString which is the concatenation of all the strings in a StaticStringList
  * Note:  keeps the \0 between the strings
  */
-//template<typename I1, typename I2> struct concatenate_helper;
-//template<std::size_t... I1, std::size_t... I2> struct concatenate_helper<std::index_sequence<I1...>, std::index_sequence<I2...>> {
-//    static constexpr int size = sizeof...(I1) + sizeof...(I2);
-//    static constexpr auto concatenate(const StaticString<sizeof...(I1)> &s1, const StaticString<sizeof...(I2)> &s2) {
-//        StaticStringArray<size> d = { s1[I1]... , s2[I2]... };
-//        return makeStaticString(d);
-//    }
-//};
-
 template<class T>
 constexpr auto store(char*& p, const T& s) {
     for (auto chr : s.data) *p++ = chr;
     return 0;
 }
-
 template<size_t ... Ls, size_t Offset, size_t... Is>
 constexpr auto concatenate(const constple::TupleImpl<TypePack<StaticString<Ls>...>, Offset, index_sequence<Is...>>& ssl) {
     StaticString<summed<Ls...>> r;
@@ -53,13 +43,6 @@ constexpr auto concatenate(const constple::TupleImpl<TypePack<StaticString<Ls>..
     return r;
 }
 constexpr StaticString<1> concatenate(StaticStringList<>) { return {'\0'}; }
-
-//template<typename T> constexpr auto concatenate(StaticStringList<binary::Leaf<T>> s) { return s.root.data; }
-/*template<typename A, typename B> constexpr auto concatenate(StaticStringList<binary::Node<A,B>> s) {
-    auto a = concatenate(binary::tree<A>{s.root.a});
-    auto b = concatenate(binary::tree<B>{s.root.b});
-    return concatenate_helper<make_index_sequence<a.size>, make_index_sequence<b.size>>::concatenate(a, b);
-}*/
 
 // Match MetaDataFlags constants form the MetaDataFlags in qmetaobject_p.h
 enum : uint { IsUnresolvedType = 0x80000000, IsUnresolvedNotifySignal = 0x70000000 };
@@ -80,7 +63,6 @@ struct IntermediateState {
     /// add a string to the strings state and add its index to the end of the int array
     template<std::size_t L>
     constexpr auto addString(const StaticString<L> & s) const {
-        //auto s2 = binary::tree_append(strings, s);
         auto s2 = strings.append(s);
         return IntermediateState<decltype(s2), Ints..., Strings::size>{s2};
     }
@@ -88,7 +70,6 @@ struct IntermediateState {
     /// same as before but add the IsUnresolvedType flag
     template<uint Flag = IsUnresolvedType, std::size_t L>
     constexpr auto addTypeString(const StaticString<L> & s) const {
-        //auto s2 = binary::tree_append(strings, s);
         auto s2 = strings.append(s);
         return IntermediateState<decltype(s2), Ints...,
             Flag | Strings::size>{s2};
@@ -527,7 +508,6 @@ constexpr auto generateDataArray(const ObjI &objectInfo) {
     constexpr int enumValueOffset = constructorParamIndex +
         paramOffset<decltype(objectInfo.constructors)>(make_index_sequence<ObjI::constructorCount>{});
 
-    //auto stringData = binary::tree_append(binary::tree_append(binary::tree<>{} , objectInfo.name), StaticString<1>{'\0'});
     auto stringData = makeStaticStringList(objectInfo.name, StaticString<1>{'\0'});
     IntermediateState<decltype(stringData),
             QT_VERSION >= QT_VERSION_CHECK(5, 12, 0) ? 8 : 7, // revision
@@ -616,7 +596,6 @@ constexpr const QByteArrayData *build_string_data()  {
 }
 template<typename T, std::size_t... I>
 constexpr const QByteArrayData *build_string_data(std::index_sequence<I...>)  {
-    //return build_string_data<T, decltype(binary::get<I>(T::string_data))::size...>();
     return build_string_data<T, decltype(constple::get<I>(T::string_data))::size...>();
 }
 

--- a/src/wobjectimpl.h
+++ b/src/wobjectimpl.h
@@ -508,7 +508,7 @@ constexpr auto generateDataArray(const ObjI &objectInfo) {
     constexpr int enumValueOffset = constructorParamIndex +
         paramOffset<decltype(objectInfo.constructors)>(make_index_sequence<ObjI::constructorCount>{});
 
-    auto stringData = makeStaticStringList(objectInfo.name, StaticString<1>{'\0'});
+    auto stringData = makeStaticStringList().append(objectInfo.name).append(StaticString<1>{'\0'});
     IntermediateState<decltype(stringData),
             QT_VERSION >= QT_VERSION_CHECK(5, 12, 0) ? 8 : 7, // revision
             0,       // classname

--- a/src/wobjectimpl.h
+++ b/src/wobjectimpl.h
@@ -35,10 +35,10 @@ template<std::size_t... I1, std::size_t... I2> struct concatenate_helper<std::in
     static constexpr int size = sizeof...(I1) + sizeof...(I2);
     static constexpr auto concatenate(const StaticString<sizeof...(I1)> &s1, const StaticString<sizeof...(I2)> &s2) {
         StaticStringArray<size> d = { s1[I1]... , s2[I2]... };
-        return StaticString<size>( d );
+        return makeStaticString(d);
     }
 };
-constexpr StaticString<1> concatenate(StaticStringList<>) { return {""}; }
+constexpr StaticString<1> concatenate(StaticStringList<>) { return {0}; }
 template<typename T> constexpr auto concatenate(StaticStringList<binary::Leaf<T>> s) { return s.root.data; }
 template<typename A, typename B> constexpr auto concatenate(StaticStringList<binary::Node<A,B>> s) {
     auto a = concatenate(binary::tree<A>{s.root.a});
@@ -207,7 +207,7 @@ static constexpr auto makeObjectInfo(StaticStringArray<N> &name) {
     constexpr int sigCount = sigState.size;
     return ObjectInfo<N, decltype(methodInfo), decltype(constructorInfo), decltype(propertyInfo),
                         decltype(enumInfo), decltype(classInfo), decltype(interfaceInfo), sigCount>
-        { {name}, methodInfo, constructorInfo, propertyInfo, enumInfo, classInfo, interfaceInfo };
+        { makeStaticString(name), methodInfo, constructorInfo, propertyInfo, enumInfo, classInfo, interfaceInfo };
 }
 
 // Generator for Q_CLASSINFO to be used in generate<>()
@@ -510,7 +510,7 @@ constexpr auto generateDataArray(const ObjI &objectInfo) {
     constexpr int enumValueOffset = constructorParamIndex +
         paramOffset<decltype(objectInfo.constructors)>(make_index_sequence<ObjI::constructorCount>{});
 
-    auto stringData = binary::tree_append(binary::tree_append(binary::tree<>{} , objectInfo.name), StaticString<1>(""));
+    auto stringData = binary::tree_append(binary::tree_append(binary::tree<>{} , objectInfo.name), StaticString<1>{0});
     IntermediateState<decltype(stringData),
             QT_VERSION >= QT_VERSION_CHECK(5, 12, 0) ? 8 : 7, // revision
             0,       // classname

--- a/src/wobjectimpl.h
+++ b/src/wobjectimpl.h
@@ -38,7 +38,7 @@ template<std::size_t... I1, std::size_t... I2> struct concatenate_helper<std::in
         return makeStaticString(d);
     }
 };
-constexpr StaticString<1> concatenate(StaticStringList<>) { return {0}; }
+constexpr StaticString<1> concatenate(StaticStringList<>) { return {'\0'}; }
 template<typename T> constexpr auto concatenate(StaticStringList<binary::Leaf<T>> s) { return s.root.data; }
 template<typename A, typename B> constexpr auto concatenate(StaticStringList<binary::Node<A,B>> s) {
     auto a = concatenate(binary::tree<A>{s.root.a});


### PR DESCRIPTION
The usage of binary tree seems quite excessive, so I tried to use a simple constexpr enabled tuple implementation as a replacement.
* The `constple::tuple` uses inheritance and starts with `Offset=1000`.
* This allows us to prepend while keeping all the base-types.
* The tuple is very basic, has no protections or features

The new tuple is only used for StaticStringList right now and it saves like 5-8% of total compile time.
So it seems to work well.

What do you think? Is it worth to complete this?