### PR TITLE
Fix QtCreator codemodel on Windows

### DIFF
--- a/src/wobjectdefs.h
+++ b/src/wobjectdefs.h
@@ -627,7 +627,7 @@ template <typename... Args> constexpr QOverload<Args...> qOverload = {};
 
 } // w_internal
 
-#ifdef Q_CC_MSVC
+#if defined(Q_CC_MSVC) && !defined(Q_CC_CLANG)
 // Workaround for MSVC: expension rules are different so we need some extra macro.
 #define W_MACRO_MSVC_EXPAND(...) __VA_ARGS__
 #define W_MACRO_MSVC_DELAY(X,...) W_MACRO_MSVC_EXPAND(X(__VA_ARGS__))


### PR DESCRIPTION
allow ClangCodeModel to parse through the Verdigris macros even though it's marked compatible to MSVC.

This is also needed to compile with `clang-cl.exe` on Windows.