### PR TITLE
WIP: Attempt at name override

### DIFF
--- a/src/wobjectdefs.h
+++ b/src/wobjectdefs.h
@@ -221,6 +221,28 @@ constexpr std::integral_constant<int, int(w_internal::PropertyFlags::Final)> W_F
 
 namespace w_internal {
 
+
+template<class T>
+struct W_TypeWrap {};
+
+template<class T>
+constexpr void W_ClassNameOverride(W_TypeWrap<T> = {});
+
+template<class T>
+constexpr auto overrideOrDefaultName(const StringView& defaultName) ->
+    std::enable_if_t<std::is_same<void, decltype (W_ClassNameOverride(W_TypeWrap<T>{}))>::value, StringView>
+{
+    return defaultName;
+}
+
+template<class T>
+constexpr auto overrideOrDefaultName(const StringView&) ->
+    std::enable_if_t<!std::is_same<void, decltype (W_ClassNameOverride(W_TypeWrap<T>{}))>::value, StringView>
+{
+    return W_ClassNameOverride(W_TypeWrap<T>{});
+}
+
+
 /// Holds information about a method
 template<typename F, int Flags, typename IC, typename ParamTypes, typename ParamNames = StringViewArray<>>
 struct MetaMethodInfo {

--- a/src/wobjectimpl.h
+++ b/src/wobjectimpl.h
@@ -1072,11 +1072,14 @@ QT_WARNING_POP
 
 #define W_OBJECT_IMPL_COMMON(INLINE, ...) \
     W_MACRO_TEMPLATE_STUFF(__VA_ARGS__) struct W_MACRO_FIRST_REMOVEPAREN(__VA_ARGS__)::W_MetaObjectCreatorHelper { \
-        struct Name { static constexpr auto value = w_internal::viewLiteral(W_MACRO_STRIGNIFY(W_MACRO_FIRST_REMOVEPAREN(__VA_ARGS__))); }; \
-        using ObjectInfo = w_internal::ObjectInfo<W_MACRO_FIRST_REMOVEPAREN(__VA_ARGS__)::W_ThisType, Name>; \
+        struct Name { \
+            static constexpr auto defaultName = w_internal::viewLiteral(W_MACRO_STRIGNIFY(W_MACRO_FIRST_REMOVEPAREN(__VA_ARGS__))); \
+            static constexpr auto value = w_internal::overrideOrDefaultName<typename W_MACRO_FIRST_REMOVEPAREN(__VA_ARGS__)::W_ThisType>(defaultName); \
+        }; \
+        using ObjectInfo = w_internal::ObjectInfo<typename W_MACRO_FIRST_REMOVEPAREN(__VA_ARGS__)::W_ThisType, Name>; \
     }; \
     W_MACRO_TEMPLATE_STUFF(__VA_ARGS__) INLINE const QT_INIT_METAOBJECT QMetaObject W_MACRO_FIRST_REMOVEPAREN(__VA_ARGS__)::staticMetaObject = \
-        w_internal::FriendHelper::createMetaObject<W_MACRO_FIRST_REMOVEPAREN(__VA_ARGS__)::W_ThisType>();
+        w_internal::FriendHelper::createMetaObject<typename W_MACRO_FIRST_REMOVEPAREN(__VA_ARGS__)::W_ThisType>();
 
 /// \macro W_OBJECT_IMPL(TYPE [, TEMPLATE_STUFF])
 /// This macro expand to the code that instantiate the QMetaObject. It must be placed outside of


### PR DESCRIPTION
Refers to #55 

I hacked together this solution to resolve our naming of templates problem.

Now custom type names can be specified like this:
```
constexpr auto W_ClassNameOverride(w_internal::W_TypeWrap<StageQml> = {}) {
    return w_internal::makeStaticString("Stage");
}
```

There's a few points for discussion in there:
- The `W_TypeWrap` template is introduced, to allow the override to be found anywhere via Argument-Dependent Lookup
- The namespacing is off, it isn't so nice to require users to reach into the w_internal namespace
- I would like to shorten the definition for a name override, but apparently the makeStaticString() call is required to correctly wrap the char array

Please have a look and comment.

Regards,
Jonathan