### PR TITLE
Make all tests discoverable by QtCreator

### DIFF
--- a/tests/basic/tst_basic.cpp
+++ b/tests/basic/tst_basic.cpp
@@ -31,7 +31,7 @@ class tst_Basic : public QObject
 
     struct SubObject;
 
-private /*slots*/:
+private slots:
     void firstTest();
     W_SLOT(firstTest, W_Access::Private)
 

--- a/tests/internal/tst_internal.cpp
+++ b/tests/internal/tst_internal.cpp
@@ -37,7 +37,7 @@ class tst_Internal : public QObject
 {
     W_OBJECT(tst_Internal)
 
-private:
+private slots:
     void removedScope() {
         QCOMPARE(w_internal::removedScopeSize("foo"), int(sizeof("foo")));
         QCOMPARE(w_internal::removedScopeSize("::foo"), int(sizeof("foo")));

--- a/tests/manyproperties/tst_manyproperties.cpp
+++ b/tests/manyproperties/tst_manyproperties.cpp
@@ -24,7 +24,7 @@ class tst_ManyProperties : public QObject
 {
     W_OBJECT(tst_ManyProperties)
 
-private:
+private slots:
     void manyProperties();
     W_SLOT(manyProperties)
 };

--- a/tests/qt/qmetaenum/tst_qmetaenum.cpp
+++ b/tests/qt/qmetaenum/tst_qmetaenum.cpp
@@ -36,18 +36,24 @@
 class tst_QMetaEnum : public QObject
 {
     W_OBJECT(tst_QMetaEnum)
+
+private slots:
+    void fromType();
+    void valuesToKeys_data();
+    void valuesToKeys();
+    void defaultConstructed();
+
+    W_SLOT(fromType)
+    W_SLOT(valuesToKeys_data)
+    W_SLOT(valuesToKeys)
+    W_SLOT(defaultConstructed)
+
 public:
     enum SuperEnum { SuperValue1 = 1 , SuperValue2 = 2 };
     enum Flag { Flag1 = 1 , Flag2 = 2 };
     W_DECLARE_FLAGS(Flags, Flag)
     W_ENUM(SuperEnum, SuperValue1, SuperValue2)
     W_FLAG(Flags, Flag1, Flag2)
-
-private:
-    void fromType(); W_SLOT(fromType)
-    void valuesToKeys_data(); W_SLOT(valuesToKeys_data)
-    void valuesToKeys(); W_SLOT(valuesToKeys)
-    void defaultConstructed();
 };
 
 W_OBJECT_IMPL(tst_QMetaEnum)

--- a/tests/qt/qmetamethod/tst_qmetamethod.cpp
+++ b/tests/qt/qmetamethod/tst_qmetamethod.cpp
@@ -39,16 +39,22 @@ class tst_QMetaMethod : public QObject
     W_OBJECT(tst_QMetaMethod)
 
 private slots:
-    void method_data(); W_SLOT(method_data, W_Access::Private)
-    void method(); W_SLOT(method, W_Access::Private)
+    void method_data();
+    void method();
 
-    void invalidMethod(); W_SLOT(invalidMethod, W_Access::Private)
+    void invalidMethod();
+    void comparisonOperators();
 
-    void comparisonOperators(); W_SLOT(comparisonOperators, W_Access::Private)
+    void fromSignal();
 
-    void fromSignal(); W_SLOT(fromSignal, W_Access::Private)
+    void gadget();
 
-    void gadget(); W_SLOT(gadget, W_Access::Private)
+    W_SLOT(method_data, W_Access::Private)
+    W_SLOT(method, W_Access::Private)
+    W_SLOT(invalidMethod, W_Access::Private)
+    W_SLOT(comparisonOperators, W_Access::Private)
+    W_SLOT(fromSignal, W_Access::Private)
+    W_SLOT(gadget, W_Access::Private)
 };
 
 struct CustomType { };

--- a/tests/qt/qmetaobject/tst_qmetaobject.cpp
+++ b/tests/qt/qmetaobject/tst_qmetaobject.cpp
@@ -277,39 +277,6 @@ class tst_QMetaObject : public QObject
 {
     W_OBJECT(tst_QMetaObject)
 
-public:
-    enum EnumType { EnumType1 };
-    W_ENUM(EnumType,EnumType1);
-
-    void setValue(EnumType) {}
-    EnumType getValue() const { return EnumType1; }
-
-    void set_value(EnumType) {}
-    EnumType get_value() const { return EnumType1; }
-
-    void setVal3(MyStruct) {}
-    MyStruct val3() const { MyStruct s = {42}; return s; }
-
-    void setVal4(const QList<QVariant> &list) { value4 = list; }
-    QList<QVariant> val4() const { return value4; }
-
-    void setVal5(const QVariantList &list) { value5 = list; }
-    QVariantList val5() const { return value5; }
-
-    int value6() const { return 1; }
-
-    void setVal7(MyStruct) {}
-    MyStruct value7() const { MyStruct s = {42}; return s; }
-
-    int value8() const { return 1; }
-
-    int value9() const { return 1; }
-
-    int value10() const { return 1; }
-
-    QList<QVariant> value4;
-    QVariantList value5;
-
 private slots:
     void connectSlotsByName();
     void invokeMetaMember();
@@ -406,6 +373,39 @@ private slots:
     W_SLOT(inherits, W_Access::Private)
 
     void notifySignalsInParentClass();
+
+public:
+    enum EnumType { EnumType1 };
+    W_ENUM(EnumType,EnumType1);
+
+    void setValue(EnumType) {}
+    EnumType getValue() const { return EnumType1; }
+
+    void set_value(EnumType) {}
+    EnumType get_value() const { return EnumType1; }
+
+    void setVal3(MyStruct) {}
+    MyStruct val3() const { MyStruct s = {42}; return s; }
+
+    void setVal4(const QList<QVariant> &list) { value4 = list; }
+    QList<QVariant> val4() const { return value4; }
+
+    void setVal5(const QVariantList &list) { value5 = list; }
+    QVariantList val5() const { return value5; }
+
+    int value6() const { return 1; }
+
+    void setVal7(MyStruct) {}
+    MyStruct value7() const { MyStruct s = {42}; return s; }
+
+    int value8() const { return 1; }
+
+    int value9() const { return 1; }
+
+    int value10() const { return 1; }
+
+    QList<QVariant> value4;
+    QVariantList value5;
 
 signals:
     void value6Changed()

--- a/tests/qt/qmetaproperty/tst_qmetaproperty.cpp
+++ b/tests/qt/qmetaproperty/tst_qmetaproperty.cpp
@@ -67,7 +67,6 @@ private slots:
     W_SLOT(mapProperty, W_Access::Private)
     W_SLOT(conversion, W_Access::Private)
 
-
 public:
     enum EnumType { EnumType1 };
 

--- a/tests/qt/qt.qbs
+++ b/tests/qt/qt.qbs
@@ -1,7 +1,7 @@
 import qbs
 
 Project {
-    name: "tests"
+    name: "qt"
 
     references: [
         "qmetaenum",

--- a/tests/templates/tst_templates.cpp
+++ b/tests/templates/tst_templates.cpp
@@ -23,7 +23,7 @@ class tst_Templates : public QObject
 {
     W_OBJECT(tst_Templates)
 
-private /*slots*/:
+private slots:
 
     // from https://codereview.qt-project.org/49864/
     void templatesMethod_data(); W_SLOT(templatesMethod_data, W_Access::Private)


### PR DESCRIPTION
QtCreator parses the source files to discover tests.
When we arrange the tests the right way - they can be found.

It seems too many or too big macros are an issue.