### PR TITLE
ConstExpr C++ API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ matrix:
       env:
         - QMAKESPEC=macx-clang
       install:
-        - brew install qt5
+        - HOMEBREW_NO_AUTO_UPDATE=1 brew install qt5
       before_script:
         - brew link qt5 --force
         - which qmake

--- a/src/wobjectcpp.h
+++ b/src/wobjectcpp.h
@@ -1,28 +1,15 @@
 #pragma once
 #include "wobjectdefs.h"
 
-#if __cplusplus <= 201700L
 namespace w_internal {
-
+#if __cplusplus <= 201700L
 template<bool... Bs>
 constexpr bool all() {
     bool b = true;
     ordered2<bool>({(b = b && Bs)...});
     return b;
 }
-
-} // namespace w_internal
 #endif
-
-namespace w_cpp {
-
-using w_internal::StringView;
-using w_internal::viewLiteral;
-
-template<typename T>
-constexpr auto makeProperty(StringView name, StringView type) {
-    return w_internal::MetaPropertyInfo<T>{ name, type, {}, {}, {}, {}, {} };
-}
 
 template<class F, int Flags, class IC = int, class ParamTypes = w_internal::StringViewArray<>, class ParamNames = w_internal::StringViewArray<>>
 struct MetaMethodInfoBuilder {
@@ -59,22 +46,69 @@ struct MetaMethodInfoBuilder {
         -> MetaMethodInfoBuilder<F, w_internal::summed<fs ..., Flags>, IC, ParamTypes, ParamNames> {
 #endif
             return {name, func, paramTypes, paramNames};
-}
-template<class IC2>
-constexpr auto setIntegralConstant() const -> MetaMethodInfoBuilder<F, Flags, IC2, ParamTypes, ParamNames> {
-    return {name, func, paramTypes, paramNames};
-}
+    }
+    template<class IC2>
+    constexpr auto setIntegralConstant() const -> MetaMethodInfoBuilder<F, Flags, IC2, ParamTypes, ParamNames> {
+        return {name, func, paramTypes, paramNames};
+    }
 
-constexpr auto build() const -> w_internal::MetaMethodInfo<F, Flags, IC, ParamTypes, ParamNames> {
-    return {func, name, paramTypes, paramNames};
-}
+    constexpr auto build() const -> w_internal::MetaMethodInfo<F, Flags, IC, ParamTypes, ParamNames> {
+        return {func, name, paramTypes, paramNames};
+    }
 };
 
-template<typename F>
-constexpr auto makeSignalBuilder(StringView name, F func) {
-    return MetaMethodInfoBuilder<F, W_MethodType::Signal.value>{name, func};
+} // namespace w_internal
+
+namespace w_cpp {
+
+/// Very simple constexpr version of std::string_view
+///
+/// example usage:
+///     constexpr char text[6] = "Hello"; // if you have a string literal use `viewLiteral` below.
+///     constexpr auto view = w_cpp::StringView{&text[0], &text[6]};
+///
+/// \note the end pointer has to point behind the \0
+using w_internal::StringView;
+
+/// Generate a constexpr StringView from a C++ string literal.
+///
+/// example usage:
+///     constexpr auto view & w_cpp::StringView{"Hello"};
+using w_internal::viewLiteral;
+
+/// create a compile time property description for registraton usage
+///
+/// \arg T the type of the property
+/// \arg name the compile time StringView for the property name
+/// \arg type the compile time StringView for the type of the property
+///
+/// Following methods may be called in chain:
+/// * .setGetter(F) - set the member function that returns the value of the property `() -> T`
+/// * .setSetter(F) - set the member function that changes the value of the property `(T) -> void`
+/// * .setMember(M) - set the class attribute to read and write the value of the property
+/// * .setNotify(F) - set the member function that represents the changed signal for the property
+/// * .setReset(F) - set the member function that resets the property value to it's default
+/// * .addFlag<F>() - add one or multiple flags for the property
+template<typename T>
+constexpr auto makeProperty(StringView name, StringView type) {
+    return w_internal::MetaPropertyInfo<T>{ name, type, {}, {}, {}, {}, {} };
 }
 
+/// create a builder for a signal description
+///
+/// \arg name the compile time StringView for the function name
+/// \arg func the member function that implements the signal
+///
+/// Following methods may be call in chain:
+/// * .setParamNames(StringView...) - set the names for all the function parameters (optional)
+/// * .setParamTypes(StringView...) - set the names of for all parameter types
+/// * .addFlag(Flags...) - add some methods flags
+/// * .setIntegralConstant<T>() - set a compile time integral value type as a unique identifier
+/// * .build() - build the final MethodInfo for this signal
+template<typename F>
+constexpr auto makeSignalBuilder(StringView name, F func) {
+    return w_internal::MetaMethodInfoBuilder<F, W_MethodType::Signal.value>{name, func};
+}
 
 } // namespace w_cpp
 

--- a/src/wobjectcpp.h
+++ b/src/wobjectcpp.h
@@ -1,0 +1,82 @@
+#pragma once
+#include "wobjectdefs.h"
+
+namespace w_cpp {
+
+using w_internal::StringView;
+using w_internal::viewLiteral;
+
+template<typename T>
+constexpr auto makeProperty(StringView name, StringView type) {
+    return w_internal::MetaPropertyInfo<T>{ name, type, {}, {}, {}, {}, {} };
+}
+
+template<class F, int Flags, class IC = int, class ParamTypes = w_internal::StringViewArray<>, class ParamNames = w_internal::StringViewArray<>>
+struct MetaMethodInfoBuilder {
+    StringView name;
+    F func;
+    ParamTypes paramTypes{};
+    ParamNames paramNames{};
+    static constexpr int flags = Flags;
+    using IntegralConstant = IC;
+
+    template<class... Args, class = std::enable_if_t<(std::is_same_v<std::decay_t<Args>, StringView> && ...)>>
+    constexpr auto setParamTypes(Args... paramTypes) const
+        -> MetaMethodInfoBuilder<F, Flags, IC, w_internal::StringViewArray<sizeof... (Args)>, ParamNames> {
+        return {name, func, {paramTypes...}, paramNames};
+    }
+    template<class... Args, class = std::enable_if_t<(std::is_same_v<std::decay_t<Args>, StringView> && ...)>>
+    constexpr auto setParamNames(Args... paramNames) const
+        -> MetaMethodInfoBuilder<F, Flags, IC, ParamTypes, w_internal::StringViewArray<sizeof... (Args)>> {
+        return {name, func, paramTypes, {paramNames...}};
+    }
+    template<int... fs>
+    constexpr auto addFlags(w_internal::W_MethodFlags<fs>...) const -> MetaMethodInfoBuilder<F, (fs | ... | Flags), IC, ParamTypes, ParamNames> {
+        return {name, func, paramTypes, paramNames};
+    }
+    template<class IC2>
+    constexpr auto setIntegralConstant() const -> MetaMethodInfoBuilder<F, Flags, IC2, ParamTypes, ParamNames> {
+        return {name, func, paramTypes, paramNames};
+    }
+
+    constexpr auto build() const -> w_internal::MetaMethodInfo<F, Flags, IC, ParamTypes, ParamNames> {
+        return {func, name, paramTypes, paramNames};
+    }
+};
+
+template<typename F>
+constexpr auto makeSignalBuilder(StringView name, F func) {
+    return MetaMethodInfoBuilder<F, W_MethodType::Signal.value>{name, func};
+}
+
+
+} // namespace w_cpp
+
+/// \macro W_CPP_PROPERTY(callback)
+/// create properties from a constexpr callback method.
+///
+/// example usage:
+///     template<size_t I, class = std::enable_if_t<(I<2)>>
+///     static constexpr auto myProperties() {
+///         using namespace w_cpp;
+///         if constexpr (I == 0) return makeProperty<QString>(viewLiteral("name"), viewLiteral("QString")).setGetter(&Example::getName);
+///         else return makeProperty<int>("age", "int").setMember(&Example::age);
+///     }
+///     W_CPP_PROPERTY(myProperties)
+///
+/// NOTE: you have to ensure that your callback limist valid I.
+#define W_CPP_PROPERTY(a) \
+    static constexpr size_t W_MACRO_CONCAT(a,_O) = w_internal::stateCount<__COUNTER__, w_internal::PropertyStateTag, W_ThisType**>; \
+    template<size_t I> \
+    friend constexpr auto w_state(w_internal::Index<I>, w_internal::PropertyStateTag, W_ThisType**) -> decltype(a<I-W_MACRO_CONCAT(a,_O)>()) { \
+        return a<I-W_MACRO_CONCAT(a,_O)>(); }
+
+#define W_CPP_SIGNAL(a) \
+    static constexpr size_t W_MACRO_CONCAT(a,_O) = w_internal::stateCount<__COUNTER__, w_internal::SignalStateTag, W_ThisType**>; \
+    template<size_t I> \
+    friend constexpr auto w_state(w_internal::Index<I>, w_internal::SignalStateTag, W_ThisType**) W_RETURN((a<I-W_MACRO_CONCAT(a,_O)>()))
+
+#define W_CPP_SIGNAL_IMPL(type, a, i, ...) { \
+    constexpr int index = W_ThisType::W_MACRO_CONCAT(a,_O) + i; \
+    return w_internal::SignalImplementation<type, index>{this}(__VA_ARGS__); \
+}

--- a/src/wobjectcpp.h
+++ b/src/wobjectcpp.h
@@ -73,7 +73,7 @@ using w_internal::StringView;
 /// Generate a constexpr StringView from a C++ string literal.
 ///
 /// example usage:
-///     constexpr auto view & w_cpp::StringView{"Hello"};
+///     constexpr auto view = w_cpp::viewLiteral("Hello");
 using w_internal::viewLiteral;
 
 /// create a compile time property description for registraton usage

--- a/src/wobjectcpp.h
+++ b/src/wobjectcpp.h
@@ -11,6 +11,15 @@ constexpr auto makeProperty(StringView name, StringView type) {
     return w_internal::MetaPropertyInfo<T>{ name, type, {}, {}, {}, {}, {} };
 }
 
+#if __cplusplus <= 201700L
+template<bool... Bs>
+constexpr bool all() {
+    bool b = true;
+    w_internal::ordered2<bool>({(b = b && Bs)...});
+    return b;
+}
+#endif
+
 template<class F, int Flags, class IC = int, class ParamTypes = w_internal::StringViewArray<>, class ParamNames = w_internal::StringViewArray<>>
 struct MetaMethodInfoBuilder {
     StringView name;
@@ -20,18 +29,31 @@ struct MetaMethodInfoBuilder {
     static constexpr int flags = Flags;
     using IntegralConstant = IC;
 
+#if __cplusplus > 201700L
     template<class... Args, class = std::enable_if_t<(std::is_same_v<std::decay_t<Args>, StringView> && ...)>>
+#else
+    template<class... Args, class = std::enable_if_t<all<std::is_same<std::decay_t<Args>, StringView>::value...>()>>
+#endif
     constexpr auto setParamTypes(Args... paramTypes) const
         -> MetaMethodInfoBuilder<F, Flags, IC, w_internal::StringViewArray<sizeof... (Args)>, ParamNames> {
         return {name, func, {paramTypes...}, paramNames};
     }
+#if __cplusplus > 201700L
     template<class... Args, class = std::enable_if_t<(std::is_same_v<std::decay_t<Args>, StringView> && ...)>>
+#else
+    template<class... Args, class = std::enable_if_t<all<std::is_same<std::decay_t<Args>, StringView>::value...>()>>
+#endif
     constexpr auto setParamNames(Args... paramNames) const
         -> MetaMethodInfoBuilder<F, Flags, IC, ParamTypes, w_internal::StringViewArray<sizeof... (Args)>> {
         return {name, func, paramTypes, {paramNames...}};
     }
     template<int... fs>
-    constexpr auto addFlags(w_internal::W_MethodFlags<fs>...) const -> MetaMethodInfoBuilder<F, (fs | ... | Flags), IC, ParamTypes, ParamNames> {
+    constexpr auto addFlags(w_internal::W_MethodFlags<fs>...) const
+#if __cplusplus > 201700L
+        -> MetaMethodInfoBuilder<F, (fs | ... | Flags), IC, ParamTypes, ParamNames> {
+#else
+        -> MetaMethodInfoBuilder<F, w_internal::summed<fs ..., Flags>, IC, ParamTypes, ParamNames> {
+#endif
         return {name, func, paramTypes, paramNames};
     }
     template<class IC2>
@@ -53,29 +75,49 @@ constexpr auto makeSignalBuilder(StringView name, F func) {
 } // namespace w_cpp
 
 /// \macro W_CPP_PROPERTY(callback)
-/// create properties from a constexpr callback method.
+/// allows to create multiple properties from a templated structure using regular C++.
 ///
 /// example usage:
-///     template<size_t I, class = std::enable_if_t<(I<2)>>
-///     static constexpr auto myProperties() {
-///         using namespace w_cpp;
-///         if constexpr (I == 0) return makeProperty<QString>(viewLiteral("name"), viewLiteral("QString")).setGetter(&Example::getName);
-///         else return makeProperty<int>("age", "int").setMember(&Example::age);
-///     }
-///     W_CPP_PROPERTY(myProperties)
+///     template<size_t I>
+///     struct MyProperties;
+///     template<>
+///     struct MyProperties<0> {
+///         constexpr static auto property = w_cpp::makeProperty<QString>(w_cpp::viewLiteral("name"), w_cpp::viewLiteral("QString"))
+///             .setGetter(&Example::getName);
+///     };
+///     W_CPP_PROPERTY(MyProperties)
 ///
-/// NOTE: you have to ensure that your callback limist valid I.
+/// NOTE: you have to ensure that the struct is only valid for some `I`s.
 #define W_CPP_PROPERTY(a) \
     static constexpr size_t W_MACRO_CONCAT(a,_O) = w_internal::stateCount<__COUNTER__, w_internal::PropertyStateTag, W_ThisType**>; \
     template<size_t I> \
-    friend constexpr auto w_state(w_internal::Index<I>, w_internal::PropertyStateTag, W_ThisType**) -> decltype(a<I-W_MACRO_CONCAT(a,_O)>()) { \
-        return a<I-W_MACRO_CONCAT(a,_O)>(); }
+    friend constexpr auto w_state(w_internal::Index<I>, w_internal::PropertyStateTag, W_ThisType**) W_RETURN((a<I-W_MACRO_CONCAT(a,_O)>::property))
 
+/// \macro W_CPP_SIGNAL(callback)
+/// allows to register multiple signals from a templated structure using regular C++.
+///
+/// example usage:
+///     template<size_t I>
+///     struct MySignals;
+///     template<>
+///     struct MySignals<0> {
+///         constexpr static auto signal = w_cpp::makeSignalBuilder(w_cpp::viewLiteral("nameChanged"), &Example::nameChanged).build();
+///     };
+///     W_CPP_SIGNAL(MySignals)
+///
+/// NOTE: you have to ensure that the struct is only valid for some `I`s.
 #define W_CPP_SIGNAL(a) \
     static constexpr size_t W_MACRO_CONCAT(a,_O) = w_internal::stateCount<__COUNTER__, w_internal::SignalStateTag, W_ThisType**>; \
     template<size_t I> \
-    friend constexpr auto w_state(w_internal::Index<I>, w_internal::SignalStateTag, W_ThisType**) W_RETURN((a<I-W_MACRO_CONCAT(a,_O)>()))
+    friend constexpr auto w_state(w_internal::Index<I>, w_internal::SignalStateTag, W_ThisType**) W_RETURN((a<I-W_MACRO_CONCAT(a,_O)>::signal))
 
+/// \macro W_CPP_SIGNAL_IMPL(type, callback, index)
+/// allows to implement a signal
+///
+/// example usage:
+///     template<size_t I>
+///     void notifyPropertyChanged() W_CPP_SIGNAL_IMPL(decltype (&tst_CppApi::notifyPropertyChanged<I>), MySignals, I, 0)
+///
 #define W_CPP_SIGNAL_IMPL(type, a, i, ...) { \
     constexpr int index = W_ThisType::W_MACRO_CONCAT(a,_O) + i; \
     return w_internal::SignalImplementation<type, index>{this}(__VA_ARGS__); \

--- a/src/wobjectcpp.h
+++ b/src/wobjectcpp.h
@@ -156,7 +156,6 @@ constexpr auto makeSignalBuilder(StringView name, F func) {
 ///     template<size_t I>
 ///     void notifyPropertyChanged() W_CPP_SIGNAL_IMPL(decltype (&tst_CppApi::notifyPropertyChanged<I>), MySignals, I, 0)
 ///
-#define W_CPP_SIGNAL_IMPL(type, a, i, ...) { \
+#define W_CPP_SIGNAL_IMPL(type, a, i, ...) \
     constexpr int index = W_ThisType::W_MACRO_CONCAT(a,_O) + i; \
-    return w_internal::SignalImplementation<type, index>{this}(__VA_ARGS__); \
-}
+    return w_internal::SignalImplementation<type, index>{this}(__VA_ARGS__)

--- a/src/wobjectimpl.h
+++ b/src/wobjectimpl.h
@@ -113,6 +113,16 @@ constexpr void foldMethods(F&& f) {
     foldState<L, MethodStateTag, T>(f);
 }
 
+template<class T>
+constexpr auto fetchExplicitName(const StringView& defaultName, ...) {
+    return defaultName;
+}
+
+template<class T>
+constexpr auto fetchExplicitName(const StringView&, int) -> decltype (w_explicitObjectName(static_cast<T*>(nullptr))) {
+    return w_explicitObjectName(static_cast<T*>(nullptr));
+}
+
 /// Helper to get information about the notify signal of the property within object T
 template<size_t L, size_t PropIdx, typename T, typename O>
 struct ResolveNotifySignal {
@@ -1072,7 +1082,10 @@ QT_WARNING_POP
 
 #define W_OBJECT_IMPL_COMMON(INLINE, ...) \
     W_MACRO_TEMPLATE_STUFF(__VA_ARGS__) struct W_MACRO_FIRST_REMOVEPAREN(__VA_ARGS__)::W_MetaObjectCreatorHelper { \
-        struct Name { static constexpr auto value = w_internal::viewLiteral(W_MACRO_STRIGNIFY(W_MACRO_FIRST_REMOVEPAREN(__VA_ARGS__))); }; \
+        struct Name { \
+            static constexpr auto defaultName = w_internal::viewLiteral(W_MACRO_STRIGNIFY(W_MACRO_FIRST_REMOVEPAREN(__VA_ARGS__))); \
+            static constexpr auto value = w_internal::fetchExplicitName<typename W_MACRO_FIRST_REMOVEPAREN(__VA_ARGS__)::W_ThisType>(defaultName, 0); \
+        }; \
         using ObjectInfo = w_internal::ObjectInfo<typename W_MACRO_FIRST_REMOVEPAREN(__VA_ARGS__)::W_ThisType, Name>; \
     }; \
     W_MACRO_TEMPLATE_STUFF(__VA_ARGS__) INLINE const QT_INIT_METAOBJECT QMetaObject W_MACRO_FIRST_REMOVEPAREN(__VA_ARGS__)::staticMetaObject = \

--- a/src/wobjectimpl.h
+++ b/src/wobjectimpl.h
@@ -1073,10 +1073,10 @@ QT_WARNING_POP
 #define W_OBJECT_IMPL_COMMON(INLINE, ...) \
     W_MACRO_TEMPLATE_STUFF(__VA_ARGS__) struct W_MACRO_FIRST_REMOVEPAREN(__VA_ARGS__)::W_MetaObjectCreatorHelper { \
         struct Name { static constexpr auto value = w_internal::viewLiteral(W_MACRO_STRIGNIFY(W_MACRO_FIRST_REMOVEPAREN(__VA_ARGS__))); }; \
-        using ObjectInfo = w_internal::ObjectInfo<W_MACRO_FIRST_REMOVEPAREN(__VA_ARGS__)::W_ThisType, Name>; \
+        using ObjectInfo = w_internal::ObjectInfo<typename W_MACRO_FIRST_REMOVEPAREN(__VA_ARGS__)::W_ThisType, Name>; \
     }; \
     W_MACRO_TEMPLATE_STUFF(__VA_ARGS__) INLINE const QT_INIT_METAOBJECT QMetaObject W_MACRO_FIRST_REMOVEPAREN(__VA_ARGS__)::staticMetaObject = \
-        w_internal::FriendHelper::createMetaObject<W_MACRO_FIRST_REMOVEPAREN(__VA_ARGS__)::W_ThisType>();
+        w_internal::FriendHelper::createMetaObject<typename W_MACRO_FIRST_REMOVEPAREN(__VA_ARGS__)::W_ThisType>();
 
 /// \macro W_OBJECT_IMPL(TYPE [, TEMPLATE_STUFF])
 /// This macro expand to the code that instantiate the QMetaObject. It must be placed outside of

--- a/tests/cppapi/cppapi.pro
+++ b/tests/cppapi/cppapi.pro
@@ -3,4 +3,5 @@ TARGET = tst_cppapi
 QT = core testlib
 include(../../src/verdigris.pri)
 SOURCES = tst_cppapi.cpp
-CONFIG += c++17
+
+msvc:QMAKE_CXXFLAGS += -permissive-

--- a/tests/cppapi/cppapi.pro
+++ b/tests/cppapi/cppapi.pro
@@ -1,0 +1,6 @@
+CONFIG += testcase
+TARGET = tst_cppapi
+QT = core testlib
+include(../../src/verdigris.pri)
+SOURCES = tst_cppapi.cpp
+contains(QT_CONFIG, c++1z): CONFIG += c++1z

--- a/tests/cppapi/cppapi.pro
+++ b/tests/cppapi/cppapi.pro
@@ -3,4 +3,4 @@ TARGET = tst_cppapi
 QT = core testlib
 include(../../src/verdigris.pri)
 SOURCES = tst_cppapi.cpp
-contains(QT_CONFIG, c++1z): CONFIG += c++1z
+CONFIG += c++17

--- a/tests/cppapi/cppapi.qbs
+++ b/tests/cppapi/cppapi.qbs
@@ -1,0 +1,14 @@
+import qbs
+
+Application {
+    name: "cppapi"
+    consoleApplication: true
+    type: ["application", "autotest"]
+
+    Depends { name: "Verdigris" }
+    Depends { name: "Qt.test" }
+
+    files: [
+        "tst_cppapi.cpp",
+    ]
+}

--- a/tests/cppapi/cppapi.qbs
+++ b/tests/cppapi/cppapi.qbs
@@ -7,6 +7,8 @@ Application {
 
     Depends { name: "Verdigris" }
     Depends { name: "Qt.test" }
+    Depends { name: "cpp" }
+    cpp.cxxLanguageVersion: "c++17"
 
     files: [
         "tst_cppapi.cpp",

--- a/tests/cppapi/cppapi.qbs
+++ b/tests/cppapi/cppapi.qbs
@@ -7,8 +7,6 @@ Application {
 
     Depends { name: "Verdigris" }
     Depends { name: "Qt.test" }
-    Depends { name: "cpp" }
-    cpp.cxxLanguageVersion: "c++17"
 
     files: [
         "tst_cppapi.cpp",

--- a/tests/cppapi/tst_cppapi.cpp
+++ b/tests/cppapi/tst_cppapi.cpp
@@ -4,12 +4,10 @@
 #include <QtCore/QMetaObject>
 #include <QtTest/QtTest>
 
-namespace test {
-
 template<class...> struct debug_types;
 
 template<size_t> struct Index {};
-template<size_t I> constexpr Index<I> index = {};
+template<size_t I> constexpr Index<I> mkIndex = {};
 template<size_t I> constexpr size_t indexValue(Index<I>) { return I; }
 template<class IV> constexpr size_t index_value = indexValue(IV{});
 
@@ -51,8 +49,8 @@ public:
         }
     };
     template<size_t I>
-    static constexpr auto mySignals() -> decltype (mySignalsLambda(index<I>)) {
-        return mySignalsLambda(index<I>);
+    static constexpr auto mySignals() -> decltype (mySignalsLambda(mkIndex<I>)) {
+        return mySignalsLambda(mkIndex<I>);
     }
     W_CPP_SIGNAL(mySignals)
 
@@ -74,8 +72,8 @@ private:
         }
     };
     template<size_t I>
-    static constexpr auto myProperties() -> decltype (myPropertiesLambda(index<I>)) {
-        return myPropertiesLambda(index<I>);
+    static constexpr auto myProperties() -> decltype (myPropertiesLambda(mkIndex<I>)) {
+        return myPropertiesLambda(mkIndex<I>);
     }
     W_CPP_PROPERTY(myProperties)
 };
@@ -90,7 +88,7 @@ void tst_CppApi::firstTest()
 
     m_name = "Hello";
     auto v = prop.read(this);
-    QCOMPARE(m_name, v);
+    QCOMPARE(QVariant(m_name), v);
 
     prop = mo->property(mo->indexOfProperty("age"));
     QVERIFY(prop.isValid());
@@ -126,8 +124,6 @@ void tst_CppApi::notifyTest()
 
 #endif
 
-} // namespace test
+W_OBJECT_IMPL(tst_CppApi)
 
-W_OBJECT_IMPL(test::tst_CppApi)
-
-QTEST_MAIN(test::tst_CppApi)
+QTEST_MAIN(tst_CppApi)

--- a/tests/cppapi/tst_cppapi.cpp
+++ b/tests/cppapi/tst_cppapi.cpp
@@ -4,6 +4,8 @@
 #include <QtCore/QMetaObject>
 #include <QtTest/QtTest>
 
+namespace test {
+
 template<class...> struct debug_types;
 
 template<size_t> struct Index {};
@@ -15,7 +17,7 @@ class tst_CppApi : public QObject
 {
     W_OBJECT(tst_CppApi)
 
-#ifndef Q_CC_GNU // GCC does not resolve the signals
+#if !defined(Q_CC_GNU) || defined(Q_CC_CLANG) // GCC does not resolve the signals
 
 private slots:
     void firstTest();
@@ -48,7 +50,7 @@ public:
             return makeSignalBuilder(viewLiteral("ageChanged"), &tst_CppApi::notifyPropertyChanged<1>).build();
         }
     };
-    template<size_t I, class = std::enable_if_t<(I<2)>>
+    template<size_t I>
     static constexpr auto mySignals() -> decltype (mySignalsLambda(index<I>)) {
         return mySignalsLambda(index<I>);
     }
@@ -71,14 +73,12 @@ private:
                 .setNotify(&tst_CppApi::notifyPropertyChanged<1>);
         }
     };
-    template<size_t I, class = std::enable_if_t<(I<2)>>
+    template<size_t I>
     static constexpr auto myProperties() -> decltype (myPropertiesLambda(index<I>)) {
         return myPropertiesLambda(index<I>);
     }
     W_CPP_PROPERTY(myProperties)
 };
-
-W_OBJECT_IMPL(tst_CppApi)
 
 void tst_CppApi::firstTest()
 {
@@ -123,8 +123,11 @@ void tst_CppApi::notifyTest()
 
 #else // Q_CC_GNU
 };
-W_OBJECT_IMPL(tst_CppApi)
 
 #endif
 
-QTEST_MAIN(tst_CppApi)
+} // namespace test
+
+W_OBJECT_IMPL(test::tst_CppApi)
+
+QTEST_MAIN(test::tst_CppApi)

--- a/tests/cppapi/tst_cppapi.cpp
+++ b/tests/cppapi/tst_cppapi.cpp
@@ -1,15 +1,7 @@
 #include <wobjectcpp.h>
 #include <wobjectimpl.h>
-#include <QtCore/QObject>
 #include <QtCore/QMetaObject>
 #include <QtTest/QtTest>
-
-template<class...> struct debug_types;
-
-template<size_t> struct Index {};
-template<size_t I> constexpr Index<I> mkIndex = {};
-template<size_t I> constexpr size_t indexValue(Index<I>) { return I; }
-template<class IV> constexpr size_t index_value = indexValue(IV{});
 
 class tst_CppApi : public QObject
 {

--- a/tests/cppapi/tst_cppapi.cpp
+++ b/tests/cppapi/tst_cppapi.cpp
@@ -24,7 +24,9 @@ public:
     QString getName() const { return m_name; }
 
     template<size_t I>
-    void notifyPropertyChanged() W_CPP_SIGNAL_IMPL(decltype (&tst_CppApi::notifyPropertyChanged<I>), MySignals, I, 0)
+    void notifyPropertyChanged() {
+        W_CPP_SIGNAL_IMPL(decltype (&tst_CppApi::notifyPropertyChanged<I>), MySignals, I, 0);
+    }
 
 #if __cplusplus > 201700L
     template<size_t I>

--- a/tests/cppapi/tst_cppapi.cpp
+++ b/tests/cppapi/tst_cppapi.cpp
@@ -1,0 +1,130 @@
+#include <wobjectcpp.h>
+#include <wobjectimpl.h>
+#include <QtCore/QObject>
+#include <QtCore/QMetaObject>
+#include <QtTest/QtTest>
+
+template<class...> struct debug_types;
+
+template<size_t> struct Index {};
+template<size_t I> constexpr Index<I> index = {};
+template<size_t I> constexpr size_t indexValue(Index<I>) { return I; }
+template<class IV> constexpr size_t index_value = indexValue(IV{});
+
+class tst_CppApi : public QObject
+{
+    W_OBJECT(tst_CppApi)
+
+#ifndef Q_CC_GNU // GCC does not resolve the signals
+
+private slots:
+    void firstTest();
+    W_SLOT(firstTest, W_Access::Private)
+    void notifyTest();
+    W_SLOT(notifyTest, W_Access::Private)
+
+private:
+    QString m_name{};
+public:
+    int m_age{};
+
+public:
+    QString getName() const { return m_name; }
+
+    //void baseNotify() W_SIGNAL(baseNotify)
+
+    template<size_t I>
+    void notifyPropertyChanged() {
+        W_CPP_SIGNAL_IMPL(decltype (&tst_CppApi::notifyPropertyChanged<I>), mySignals, I, 0)
+    }
+
+    static constexpr auto mySignalsLambda = [](auto i) {
+        constexpr auto I = index_value<decltype (i)>;
+        using namespace w_cpp;
+        if constexpr (I == 0) {
+            return makeSignalBuilder(viewLiteral("nameChanged"), &tst_CppApi::notifyPropertyChanged<0>).build();
+        }
+        else if constexpr (I == 1) {
+            return makeSignalBuilder(viewLiteral("ageChanged"), &tst_CppApi::notifyPropertyChanged<1>).build();
+        }
+    };
+    template<size_t I, class = std::enable_if_t<(I<2)>>
+    static constexpr auto mySignals() -> decltype (mySignalsLambda(index<I>)) {
+        return mySignalsLambda(index<I>);
+    }
+    W_CPP_SIGNAL(mySignals)
+
+private:
+    // W_PROPERTY(QString, name2 READ getName NOTIFY notifyPropertyChanged<0>)
+
+    static constexpr auto myPropertiesLambda = [](auto i) {
+        constexpr auto I = index_value<decltype (i)>;
+        using namespace w_cpp;
+        if constexpr (I == 0) {
+            return makeProperty<QString>(viewLiteral("name"), viewLiteral("QString"))
+                .setGetter(&tst_CppApi::getName)
+                .setNotify(&tst_CppApi::notifyPropertyChanged<0>);
+        }
+        else if constexpr (I == 1) {
+            return makeProperty<int>(viewLiteral("age"), viewLiteral("int"))
+                .setMember(&tst_CppApi::m_age)
+                .setNotify(&tst_CppApi::notifyPropertyChanged<1>);
+        }
+    };
+    template<size_t I, class = std::enable_if_t<(I<2)>>
+    static constexpr auto myProperties() -> decltype (myPropertiesLambda(index<I>)) {
+        return myPropertiesLambda(index<I>);
+    }
+    W_CPP_PROPERTY(myProperties)
+};
+
+W_OBJECT_IMPL(tst_CppApi)
+
+void tst_CppApi::firstTest()
+{
+    const QMetaObject *mo = metaObject();
+
+    QMetaProperty prop = mo->property(mo->indexOfProperty("name"));
+    QVERIFY(prop.isValid());
+    QVERIFY(!prop.isConstant());
+
+    m_name = "Hello";
+    auto v = prop.read(this);
+    QCOMPARE(m_name, v);
+
+    prop = mo->property(mo->indexOfProperty("age"));
+    QVERIFY(prop.isValid());
+    QVERIFY(!prop.isConstant());
+
+    prop.write(this, 23);
+    QCOMPARE(23, m_age);
+}
+
+void tst_CppApi::notifyTest()
+{
+    bool notified0 = false;
+    auto conn0 = connect(this, &tst_CppApi::notifyPropertyChanged<0>, [&](){
+        notified0 = true;
+    });
+    notifyPropertyChanged<0>();
+
+    QVERIFY(notified0);
+
+    bool notified1 = false;
+    auto conn1 = connect(this, &tst_CppApi::notifyPropertyChanged<1>, [&](){
+        notified1 = true;
+    });
+    setProperty("age", 100);
+    QVERIFY(notified1);
+
+    disconnect(conn0);
+    disconnect(conn1);
+}
+
+#else // Q_CC_GNU
+};
+W_OBJECT_IMPL(tst_CppApi)
+
+#endif
+
+QTEST_MAIN(tst_CppApi)

--- a/tests/templates/tst_templates.cpp
+++ b/tests/templates/tst_templates.cpp
@@ -33,6 +33,8 @@ private slots:
     void connectTemplate();  W_SLOT(connectTemplate, W_Access::Private)
 
     void gadget(); W_SLOT(gadget, W_Access::Private)
+
+    void smartPointer(); W_SLOT(smartPointer, W_Access::Private)
 };
 
 
@@ -261,6 +263,29 @@ void tst_Templates::gadget()
     testGadget(QByteArray("toto"));
 }
 
+#include <wobjectcpp.h>
+
+namespace test {
+
+template<typename T>
+class RegisterTemplate : public QObject {
+    W_OBJECT(RegisterTemplate)
+};
+using IntTest = RegisterTemplate<int>;
+
+constexpr auto w_explicitObjectName(IntTest*) {
+    return w_cpp::viewLiteral("IntTest");
+}
+
+} // namespace test
+
+void tst_Templates::smartPointer() {
+    auto smart_ptr = QSharedPointer<test::IntTest>{};
+    // note: this will fail if no w_explicitObjectName was registered
+    auto var = QVariant::fromValue(smart_ptr);
+}
+
+
 QTEST_MAIN(tst_Templates)
 
 W_REGISTER_ARGTYPE(ReduceKernel<Functor,Functor,int>*)
@@ -274,3 +299,4 @@ W_OBJECT_IMPL((TemplateTemplateParameter<C1, C2, C3>), template<template<typenam
 W_OBJECT_IMPL((MappedReducedKernel<ReducedResultType, Iterator, MapFunctor, ReduceFunctor, Reducer>), template <typename ReducedResultType, typename Iterator, typename MapFunctor, typename ReduceFunctor, typename Reducer>)
 W_OBJECT_IMPL(TemplateObject<T>, template<typename T>)
 W_GADGET_IMPL(TemplateGadget<T>, template<typename T>)
+W_OBJECT_IMPL((test::RegisterTemplate<T>), template<typename T>)

--- a/tests/tests.pro
+++ b/tests/tests.pro
@@ -2,4 +2,5 @@ TEMPLATE = subdirs
 
 SUBDIRS += internal basic qt templates manyproperties
 
-!lessThan(QT_VERSION,5.12.0): SUBDIRS += cppapi
+equals(QT_MAJOR_VERSION, 5):greaterThan(QT_MINOR_VERSION, 11): SUBDIRS += cppapi
+greaterThan(QT_MAJOR_VERSION, 5): SUBDIRS += cppapi

--- a/tests/tests.pro
+++ b/tests/tests.pro
@@ -1,3 +1,3 @@
 TEMPLATE = subdirs
 
-SUBDIRS += internal basic qt templates manyproperties
+SUBDIRS += internal basic cppapi qt templates manyproperties

--- a/tests/tests.pro
+++ b/tests/tests.pro
@@ -2,5 +2,4 @@ TEMPLATE = subdirs
 
 SUBDIRS += internal basic qt templates manyproperties
 
-equals(QT_MAJOR_VERSION, 5):greaterThan(QT_MINOR_VERSION, 11): SUBDIRS += cppapi
-greaterThan(QT_MAJOR_VERSION, 5): SUBDIRS += cppapi
+!gcc:SUBDIRS += cppapi

--- a/tests/tests.pro
+++ b/tests/tests.pro
@@ -1,3 +1,5 @@
 TEMPLATE = subdirs
 
-SUBDIRS += internal basic cppapi qt templates manyproperties
+SUBDIRS += internal basic qt templates manyproperties
+
+!lessThan(QT_VERSION,5.12.0): SUBDIRS += cppapi

--- a/tests/tests.qbs
+++ b/tests/tests.qbs
@@ -4,10 +4,11 @@ Project {
     name: "tests"
 
     references: [
-        "internal",
         "basic",
+        "cppapi",
+        "internal",
+        "manyproperties",
         "qt",
         "templates",
-        "manyproperties"
     ]
 }

--- a/tutorial/cpp_tutorial.cpp
+++ b/tutorial/cpp_tutorial.cpp
@@ -1,0 +1,166 @@
+/**
+  This file presents Verdigris C++ API.
+
+  This allows you to add multiple properties with a single macro invocation.
+
+  You will create a basic PropertyHolder template that allows you to very easily make
+  Properties available to QML.
+ */
+
+/** ******************************************************************************************** **/
+/** INTRODUCTION **/
+
+// Include the C++ API for Verdigris
+#include <wobjectcpp.h>
+
+// To implement the template QObjects you need the Verdigris implementation as well
+#include <wobjectimpl.h>
+
+// And because you will inherit from QObject you also need to QObject header
+#include <QObject>
+
+// To simplify matters your properties make use of QVariant
+#include <QVariant>
+
+// std::tuple will handle storage for your properties
+#include <tuple>
+
+// You want to represent each property as a strong type
+// note: This is a very basic strong type template but sufficient for this tutorial
+template<class V, class... Tags>
+struct Strong {
+    V v;
+};
+
+// Use the Strong type template to define the person properties
+using Name = Strong<QString, struct NameTag>;
+using BirthYear = Strong<int, struct BirthYearTag>;
+
+// This wrapper allows you to build constexpr functions that depend on non constexpr types.
+// For example a `QString` would not be instantiatable at compile time, but `Wrap<QString>` is.
+template<class T>
+struct Wrap {};
+
+// Define names for the properties as constexpr functions.
+// These names are used by QML to access the properties
+constexpr auto getPropertyName(Wrap<Name>) { return w_cpp::viewLiteral("name"); }
+constexpr auto getPropertyName(Wrap<BirthYear>) { return w_cpp::viewLiteral("birthYear"); }
+
+// Also define the names for the changed signals as constexpr functions.
+// Hint: You might generate these names programmatically from the PropertyName at compile time.
+constexpr auto getPropertyChangedName(Wrap<Name>) { return w_cpp::viewLiteral("nameChanged"); }
+constexpr auto getPropertyChangedName(Wrap<BirthYear>) { return w_cpp::viewLiteral("birthYearChanged"); }
+
+// Now it's time to build the GenericPropertyHolder as a templated QObject.
+// Thanks to Verdigris it accepts any number of strong typed properties as template arguments.
+template<class... Properties>
+class GenericPropertyHolder : public QObject {
+    // W_OBJECT macro as usual for Verdigris
+    W_OBJECT(GenericPropertyHolder)
+
+    // To keep matters simple you store the properties as a std::tuple for now
+    using Storage = std::tuple<Properties...>;
+    Storage m_storage{};
+
+    // You can also use std::tuple to resolve the property type for a given index.
+    template<size_t I>
+    using PropertyAt = std::remove_reference_t<decltype (std::get<I>(std::declval<Storage>()))>;
+
+public:
+    // A constructor that fills the intial values for all the properties
+    GenericPropertyHolder(Properties... properties, QObject* parent = {})
+        : QObject(parent), m_storage(std::move(properties)...) {}
+
+private:
+    // Now you need to implement Signals, Getter, Setter and registrations for all properties.
+    // To prevent repetition you can simply create indexed template functions and use the C++ Verdigris API.
+
+    // Create a property changed signal implemenation for all properties in one template
+    template<size_t I>
+    void propertyChanged() {
+        W_CPP_SIGNAL_IMPL(decltype (&GenericPropertyHolder::propertyChanged<I>), PropertyChangedSignals, I, 0);
+    }
+
+    // Register a property changed signal for all properties
+    // Verdigris increments I starting with 0 until this template is invalid.
+    // So you should limit the instantiation to the number of Properties.
+    template<size_t I, class = std::enable_if_t<(I < sizeof...(Properties))>>
+    struct PropertyChangedSignals {
+        using Property = PropertyAt<I>;
+        constexpr static auto signalName = getPropertyChangedName(Wrap<Property>{});
+        // signal is the only thing used by the W_CPP_SIGNAL macro.
+        constexpr static auto signal =
+            w_cpp::makeSignalBuilder(signalName, &GenericPropertyHolder::propertyChanged<I>).build();
+    };
+    // The W_CPP_SIGNAL macro registers our PropertyChangedSignals template to Verdigris
+    W_CPP_SIGNAL(PropertyChangedSignals)
+
+    // Next you should implement the getter and setter functions for all properties.
+    // QML does not care about our C++ types so you can convert them directly to QVariant.
+    // notice: For useful C++ Api you would probably want to use your strong types instead of indices anyways.
+    template<size_t I>
+    auto getPropertyValue() const -> QVariant {
+        const auto& property = std::get<I>(m_storage);
+        return QVariant::fromValue(property.v);
+    }
+    template<size_t I>
+    void setPropertyValue(QVariant variant) {
+        auto& property = std::get<I>(m_storage);
+        // Before you can set the property value you have to extract the right type from the QVariant
+        using Property = PropertyAt<I>;
+        using ValueType = decltype (std::declval<Property>().v);
+        property.v = variant.value<ValueType>();
+        propertyChanged<I>(); // send notification for the property
+    }
+
+    // Finally you have everything to register all your properties
+    // Again Verdigris increments I starting with 0 until this template is no longer valid.
+    template<size_t I, class = std::enable_if_t<(I < sizeof...(Properties))>>
+    struct RegisterProperties {
+        using Property = PropertyAt<I>;
+        constexpr static auto name = getPropertyName(Wrap<Property>{});
+        // property is the only thing used by the W_CPP_PROPERTY macro.
+        constexpr static auto property =
+            w_cpp::makeProperty<QVariant>(name, w_cpp::viewLiteral("QVariant"))
+                .setGetter(&GenericPropertyHolder::getPropertyValue<I>)
+                .setSetter(&GenericPropertyHolder::setPropertyValue<I>)
+                .setNotify(&GenericPropertyHolder::propertyChanged<I>);
+    };
+    W_CPP_PROPERTY(RegisterProperties)
+};
+
+// Generate the QObject implementation for all instances of the template
+W_OBJECT_IMPL(GenericPropertyHolder<Properties...>, template<class... Properties>)
+// note: consider using W_OBJECT_IMPL_INLINE to prevent linker issues when you use the same instances from multiple compile units
+
+// For your person example you can now instanciate our template
+using PersonHolder = GenericPropertyHolder<Name, BirthYear>;
+
+// Implement a QML Quick application
+#include <QGuiApplication>
+#include <QQmlApplicationEngine>
+#include <QQmlContext>
+
+int main(int argc, char *argv[]) {
+    QCoreApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
+
+    QGuiApplication app(argc, argv);
+
+    QQmlApplicationEngine engine{};
+
+    // register your PersonHolder for QML as uncreatable type
+    qmlRegisterUncreatableType<PersonHolder>("CppTutorial", 1, 0, "PersonHolder", "");
+
+    // create a famous person of your liking
+    PersonHolder person{Name{"Albert Einstein"}, BirthYear{1879}};
+
+    // make this person accessable as global context property in QML
+    auto context = engine.rootContext();
+    context->setContextProperty("person", &person);
+
+    // now you can use it like any other QObject with properties from QML
+    engine.load(QStringLiteral("qrc:/cpp_tutorial.qml"));
+    return app.exec();
+}
+
+// Notice that with the GenericPropertyHolder template in place, you can add more properties very easy.

--- a/tutorial/cpp_tutorial.cpp
+++ b/tutorial/cpp_tutorial.cpp
@@ -144,7 +144,7 @@ using PersonHolder = GenericPropertyHolder<Name, BirthYear>;
 int main(int argc, char *argv[]) {
     QCoreApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
 
-    QGuiApplication app(argc, argv);
+    QGuiApplication app{argc, argv};
 
     QQmlApplicationEngine engine{};
 
@@ -152,7 +152,7 @@ int main(int argc, char *argv[]) {
     qmlRegisterUncreatableType<PersonHolder>("CppTutorial", 1, 0, "PersonHolder", "");
 
     // create a famous person of your liking
-    PersonHolder person{Name{"Albert Einstein"}, BirthYear{1879}};
+    PersonHolder person{Name{"Albert Einstein"}, BirthYear{1879}, {}};
 
     // make this person accessable as global context property in QML
     auto context = engine.rootContext();

--- a/tutorial/cpp_tutorial.qml
+++ b/tutorial/cpp_tutorial.qml
@@ -1,0 +1,56 @@
+import QtQuick 2.2
+import QtQuick.Layouts 1.1
+import QtQuick.Controls 1.2
+import QtQuick.Window 2.0
+import CppTutorial 1.0
+
+Window {
+    visible: true
+    width: 640
+    height: 480
+    title: qsTr("Cpp Tutorial")
+
+    ColumnLayout {
+        anchors.fill: parent
+        anchors.margins: 20
+
+        TextField {
+            Layout.fillWidth: true
+            readOnly: true
+            placeholderText: "Missing name"
+            text: person.name
+        }
+        RowLayout {
+            Layout.fillWidth: true
+            TextField {
+                Layout.fillWidth: true
+                readOnly: true
+                text: person.birthYear
+            }
+            Button {
+                text: "+1"
+                onClicked: person.birthYear += +1
+            }
+            Button {
+                text: "-1"
+                onClicked: person.birthYear += -1
+            }
+        }
+        Item {
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+        }
+        RowLayout {
+            Layout.fillWidth: true
+            TextField {
+                id: renameName
+                Layout.fillWidth: true
+                placeholderText: "Enter new name here"
+            }
+            Button {
+                text: "Rename"
+                onClicked: person.name = renameName.text
+            }
+        }
+    }
+}

--- a/tutorial/cpp_tutorial.qrc
+++ b/tutorial/cpp_tutorial.qrc
@@ -1,0 +1,5 @@
+<RCC>
+    <qresource prefix="/">
+        <file>cpp_tutorial.qml</file>
+    </qresource>
+</RCC>

--- a/tutorial/tutorial.qbs
+++ b/tutorial/tutorial.qbs
@@ -16,7 +16,6 @@ Project {
     Application {
         name: "cpp_tutorial"
         consoleApplication: true
-        condition: !qbs.toolchain.contains('gcc')
 
         Depends { name: "Verdigris" }
         Depends { name: "Qt.quick" }

--- a/tutorial/tutorial.qbs
+++ b/tutorial/tutorial.qbs
@@ -1,13 +1,30 @@
 import qbs
 
-Application {
-    name: "tutorial"
-    consoleApplication: true
-    type: ["application"]
+Project {
 
-    Depends { name: "Verdigris" }
+    Application {
+        name: "tutorial"
+        consoleApplication: true
 
-    files: [
-        "tutorial.cpp"
-    ]
+        Depends { name: "Verdigris" }
+
+        files: [
+            "tutorial.cpp"
+        ]
+    }
+
+    Application {
+        name: "cpp_tutorial"
+        consoleApplication: true
+        condition: !qbs.toolchain.contains('gcc')
+
+        Depends { name: "Verdigris" }
+        Depends { name: "Qt.quick" }
+
+        files: [
+            "cpp_tutorial.cpp",
+            "cpp_tutorial.qml",
+            "cpp_tutorial.qrc",
+        ]
+    }
 }

--- a/verdigris.qbs
+++ b/verdigris.qbs
@@ -15,6 +15,7 @@ Project {
         name: "Verdigris"
 
         files: [
+            "src/wobjectcpp.h",
             "src/wobjectdefs.h",
             "src/wobjectimpl.h",
         ]


### PR DESCRIPTION
Implements issue #50 

I created a third header. So you only use it if needed.

The following features are supported:
* Register Signals
* Implement Signals
* Register Properties

It might be extended if it's useful.

Limitations:
* No version of GCC is supported. It simply refuses to resolve the signals when used in properties.
* There is not much documentation beyond the unit test and inline documentation.