### PR TITLE
Cleanup some itches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -78,24 +78,24 @@ matrix:
         - QT_VERSION=512
         - GCC_VERSION=8
 
-#    - name: clang-3.8 qt5.6.3 -std=c++14 -lib=stdc++-5
-#      os: linux
-#      dist: trusty
-#      addons:
-#        apt:
-#          sources:
-#            - ubuntu-toolchain-r-test
-#            - llvm-toolchain-trusty-3.8
-#            - sourceline: ppa:beineri/opt-qt563-trusty
-#          packages:
-#            - clang-3.8
-#            - libstdc++-5-dev
-#            - qt56base
-#      env:
-#        - STD_CPP=C++14
-#        - QT_VERSION=56
-#        - CLANG_VERSION=3.8
-#        - QMAKESPEC=linux-clang
+    - name: clang-3.8 qt5.6.3 -std=c++14 -lib=stdc++-5
+      os: linux
+      dist: trusty
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-trusty-3.8
+            - sourceline: ppa:beineri/opt-qt563-trusty
+          packages:
+            - clang-3.8
+            - libstdc++-5-dev
+            - qt56base
+      env:
+        - STD_CPP=C++14
+        - QT_VERSION=56
+        - CLANG_VERSION=3.8
+        - QMAKESPEC=linux-clang
 
     - name: clang-3.9 qt5.7.1 -std=c++14 -lib=stdc++-5
       os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -78,24 +78,24 @@ matrix:
         - QT_VERSION=512
         - GCC_VERSION=8
 
-    - name: clang-3.8 qt5.6.3 -std=c++14 -lib=stdc++-5
-      os: linux
-      dist: trusty
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-            - llvm-toolchain-trusty-3.8
-            - sourceline: ppa:beineri/opt-qt563-trusty
-          packages:
-            - clang-3.8
-            - libstdc++-5-dev
-            - qt56base
-      env:
-        - STD_CPP=C++14
-        - QT_VERSION=56
-        - CLANG_VERSION=3.8
-        - QMAKESPEC=linux-clang
+#    - name: clang-3.8 qt5.6.3 -std=c++14 -lib=stdc++-5
+#      os: linux
+#      dist: trusty
+#      addons:
+#        apt:
+#          sources:
+#            - ubuntu-toolchain-r-test
+#            - llvm-toolchain-trusty-3.8
+#            - sourceline: ppa:beineri/opt-qt563-trusty
+#          packages:
+#            - clang-3.8
+#            - libstdc++-5-dev
+#            - qt56base
+#      env:
+#        - STD_CPP=C++14
+#        - QT_VERSION=56
+#        - CLANG_VERSION=3.8
+#        - QMAKESPEC=linux-clang
 
     - name: clang-3.9 qt5.7.1 -std=c++14 -lib=stdc++-5
       os: linux
@@ -168,13 +168,15 @@ matrix:
             -p autotest-runner
 
 before_script:
-  - if [[ $GCC_VERSION ]]; then
-      sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-${GCC_VERSION} 90;
-      g++ --version;
+  - |
+    if [[ $GCC_VERSION ]]; then
+      sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-${GCC_VERSION} 90
+      g++ --version
     fi
-  - if [[ $CLANG_VERSION ]]; then
-      sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-${CLANG_VERSION} 90;
-      clang++ --version;
+  - |
+    if [[ $CLANG_VERSION ]]; then
+      ln -s $(which clang++-${CLANG_VERSION}) ~/bin/clang++
+      clang++ --version
     fi
   - source /opt/qt$QT_VERSION/bin/qt${QT_VERSION}-env.sh
   - which qmake

--- a/src/wobjectdefs.h
+++ b/src/wobjectdefs.h
@@ -605,7 +605,7 @@ namespace w_internal {
 /// This overload is found if no better overload was found.
 /// All overloads are found using ADL in the QObject T
 template<class State, class TPP>
-constexpr void w_state(IndexBase, State, TPP);
+void w_state(IndexBase, State, TPP);
 
 #if __cplusplus > 201700L
 template<size_t L, class State, class TPP, size_t N , size_t M, size_t X = (N+M)/2>

--- a/src/wobjectdefs.h
+++ b/src/wobjectdefs.h
@@ -116,7 +116,8 @@ constexpr auto viewValidTailsImpl(index_sequence<Is...>, index_sequence<Ts...>, 
     auto p = r.data;
     ((Is < R ? (*p++ = StringView{&ns[Ns - Ts], &ns[Ns]}) : *p), ...);
 #else
-    ordered((Is < R ? (r.data[Is] = StringView{&ns[Ns - Ts], &ns[Ns]}, 0) : 0)...);
+    auto i = 0;
+    ordered2<int>({(Is < R ? (r.data[i++] = StringView{&ns[Ns - Ts], &ns[Ns]}, 0) : 0)...});
 #endif
     return r;
 }

--- a/src/wobjectimpl.h
+++ b/src/wobjectimpl.h
@@ -841,6 +841,10 @@ struct FriendHelper {
         return _id;
     }
 
+#ifdef Q_CC_GNU
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Waddress"
+#endif
     /// Helper for implementation of qt_static_metacall for QMetaObject::IndexOfMethod
     /// T is the class, and I is the index of a method.
     /// Returns I if the argument is equal to the pointer to member function of the signal of index 'I'
@@ -853,6 +857,9 @@ struct FriendHelper {
             return I;
         return -1;
     }
+#ifdef Q_CC_GNU
+#pragma GCC diagnostic pop
+#endif
 
     /// Helper for implementation of qt_static_metacall for QMetaObject::InvokeMetaMethod
     /// T is the class, and I is the index of a method.

--- a/src/wobjectimpl.h
+++ b/src/wobjectimpl.h
@@ -182,8 +182,13 @@ struct ClassInfoGenerator {
 };
 
 /// auto-detect the access specifiers
-template <typename T, typename M, typename = void> struct isPublic : std::false_type {};
-template <typename T, typename M> struct isPublic<T, M, decltype(T::w_GetAccessSpecifierHelper(std::declval<M>()))> : std::true_type {};
+template<class T, class M>
+auto test_public(int) -> std::enable_if_t<std::is_same<void, decltype(T::w_GetAccessSpecifierHelper(M{}))>::value, std::true_type>;
+template<class T, class M>
+auto test_public(float) -> std::false_type;
+template<class T, class M>
+using isPublic = decltype(test_public<T, M>(0));
+
 template <typename T, typename M, typename = void> struct isProtected : std::false_type {};
 template <typename T, typename = std::enable_if_t<!std::is_final<T>::value>>
 struct Derived : T { template<typename M, typename X = T> static decltype(X::w_GetAccessSpecifierHelper(std::declval<M>())) test(M); };

--- a/src/wobjectimpl.h
+++ b/src/wobjectimpl.h
@@ -846,10 +846,8 @@ struct FriendHelper {
         return _id;
     }
 
-#ifdef Q_CC_GNU
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Waddress"
-#endif
+QT_WARNING_PUSH
+QT_WARNING_DISABLE_GCC("-Waddress")
     /// Helper for implementation of qt_static_metacall for QMetaObject::IndexOfMethod
     /// T is the class, and I is the index of a method.
     /// Returns I if the argument is equal to the pointer to member function of the signal of index 'I'
@@ -862,9 +860,7 @@ struct FriendHelper {
             return I;
         return -1;
     }
-#ifdef Q_CC_GNU
-#pragma GCC diagnostic pop
-#endif
+QT_WARNING_POP
 
     /// Helper for implementation of qt_static_metacall for QMetaObject::InvokeMetaMethod
     /// T is the class, and I is the index of a method.


### PR DESCRIPTION
* GCC 7.3 may warn about a possible index out of bounds - but we never execute that branch (I made this with a dynamic index, so compiler cannot reason about this)
* Silenced warings of older GCCs about the address of a member function can never be NULL - but we cannot do a different comparison (disabled the warning)
* CLANG versions on Travis were off. The preinstalled clang version was always used.
* Fixed compilation with clang 3.8.