### PR TITLE
Use constexpr string parsing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,22 +14,6 @@ matrix:
         - which qmake
         - qmake --version
 
-    - name: g++5 qt5.5.1 -std=c++14
-      os: linux
-      dist: trusty
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-            - sourceline: ppa:beineri/opt-qt551-trusty
-          packages:
-            - g++-5
-            - qt55base
-      env:
-        - STD_CPP=C++14
-        - QT_VERSION=55
-        - GCC_VERSION=5
-
     - name: g++6 qt5.5.1 -std=c++14
       os: linux
       dist: trusty
@@ -93,6 +77,22 @@ matrix:
         - STD_CPP=C++17
         - QT_VERSION=512
         - GCC_VERSION=8
+
+    - name: g++9 qt5.5.1 -std=c++14
+      os: linux
+      dist: trusty
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+            - sourceline: ppa:beineri/opt-qt551-trusty
+          packages:
+            - g++-9
+            - qt55base
+      env:
+        - STD_CPP=C++14
+        - QT_VERSION=55
+        - GCC_VERSION=9
 
     - name: clang-3.8 qt5.6.3 -std=c++14 -lib=stdc++-5
       os: linux

--- a/src/wobjectcpp.h
+++ b/src/wobjectcpp.h
@@ -65,7 +65,7 @@ namespace w_cpp {
 ///
 /// example usage:
 ///     constexpr char text[6] = "Hello"; // if you have a string literal use `viewLiteral` below.
-///     constexpr auto view = w_cpp::StringView{&text[0], &text[6]};
+///     constexpr auto view = w_cpp::StringView{&text[0], &text[5]};
 ///
 /// \note the end pointer has to point behind the \0
 using w_internal::StringView;

--- a/src/wobjectdefs.h
+++ b/src/wobjectdefs.h
@@ -1,4 +1,4 @@
-/****************************************************************************
+﻿/****************************************************************************
  *  Copyright (C) 2016-2018 Woboq GmbH
  *  Olivier Goffart <ogoffart at woboq.com>
  *  https://woboq.com/
@@ -87,7 +87,7 @@ struct StringView {
 // adding this constructor requires more constructors which generates overhead
 template<size_t N>
 constexpr auto viewLiteral(const char (&d)[N]) -> StringView {
-    return {&d[0], &d[N]};
+    return {&d[0], &d[N-1]};
 }
 
 /// raw arrays cannot be returned from functions so we wrap it
@@ -115,11 +115,11 @@ constexpr auto viewValidTailsImpl(index_sequence<Is...>, index_sequence<Ts...>, 
     auto r = StringViewArray<R>{};
 #if __cplusplus > 201700L
     auto p = r.data;
-    ((Is < R ? (*p++ = StringView{&ns[Ns - Ts], &ns[Ns]}) : *p), ...);
+    ((Is < R ? (*p++ = StringView{&ns[Ns - Ts], &ns[Ns-1]}) : *p), ...);
 #else
     auto i = 0;
     Q_UNUSED(i)
-    ordered2<int>({(Is < R ? (r.data[i++] = StringView{&ns[Ns - Ts], &ns[Ns]}, 0) : 0)...});
+    ordered2<int>({(Is < R ? (r.data[i++] = StringView{&ns[Ns - Ts], &ns[Ns-1]}, 0) : 0)...});
 #endif
     return r;
 }

--- a/src/wobjectimpl.h
+++ b/src/wobjectimpl.h
@@ -1,4 +1,4 @@
-/****************************************************************************
+﻿/****************************************************************************
  *  Copyright (C) 2016-2018 Woboq GmbH
  *  Olivier Goffart <ogoffart at woboq.com>
  *  https://woboq.com/
@@ -571,17 +571,17 @@ struct LayoutBuilder {
     uint intCount{};
 
     constexpr void addString(const StringView& s) {
-        stringSize += s.size();
+        stringSize += s.size() + 1;
         stringCount += 1;
         intCount += 1;
     }
     constexpr void addStringUntracked(const StringView& s) {
-        stringSize += s.size();
+        stringSize += s.size() + 1;
         stringCount += 1;
     }
     template<uint Flag = IsUnresolvedType>
     constexpr void addTypeString(const StringView& s) {
-        stringSize += s.size();
+        stringSize += s.size() + 1;
         stringCount += 1;
         intCount += 1;
     }
@@ -611,28 +611,31 @@ struct DataBuilder {
 
     constexpr void addString(const StringView& s) {
         for (auto c : s) *stringCharP++ = c;
+        *stringCharP++ = '\0';
         *stringOffestP++ = stringOffset;
-        *stringLengthP++ = s.size() - 1;
+        *stringLengthP++ = s.size();
         *intP++ = stringCount;
-        stringOffset += s.size() - qptrdiff(sizeof(QByteArrayData));
+        stringOffset += 1 + s.size() - qptrdiff(sizeof(QByteArrayData));
         stringCount += 1;
         intCount += 1;
     }
     constexpr void addStringUntracked(const StringView& s) {
         for (auto c : s) *stringCharP++ = c;
+        *stringCharP++ = '\0';
         *stringOffestP++ = stringOffset;
-        *stringLengthP++ = s.size() - 1;
-        stringOffset += s.size() - qptrdiff(sizeof(QByteArrayData));
+        *stringLengthP++ = s.size();
+        stringOffset += 1 + s.size() - qptrdiff(sizeof(QByteArrayData));
         stringCount += 1;
     }
 
     template<uint Flag = IsUnresolvedType>
     constexpr void addTypeString(const StringView& s) {
         for (auto c : s) *stringCharP++ = c;
+        *stringCharP++ = '\0';
         *stringOffestP++ = stringOffset;
-        *stringLengthP++ = s.size() - 1;
+        *stringLengthP++ = s.size();
         *intP++ = Flag | stringCount;
-        stringOffset += s.size() - qptrdiff(sizeof(QByteArrayData));
+        stringOffset += 1 + s.size() - qptrdiff(sizeof(QByteArrayData));
         stringCount += 1;
         intCount += 1;
     }

--- a/tests/internal/tst_internal.cpp
+++ b/tests/internal/tst_internal.cpp
@@ -31,8 +31,8 @@ namespace w_internal {
 //static_assert(std::is_same<decltype(viewValidLiterals()), StringViewArray<>>::value, "");
 constexpr auto vl1 = viewValidLiterals("H", "el");
 static_assert(std::is_same<std::decay_t<decltype(vl1)>, StringViewArray<2>>::value, "");
-static_assert (vl1[0].size() == 2, "");
-static_assert (vl1[1].size() == 3, "");
+static_assert (vl1[0].size() == 1, "");
+static_assert (vl1[1].size() == 2, "");
 static_assert(vl1[0].b[0] == 'H', "");
 static_assert(vl1[0].b[1] == '\0', "");
 static_assert(std::is_same<decltype(viewValidLiterals("H", "", "el")), StringViewArray<1>>::value, "");


### PR DESCRIPTION
I could not resist and implemented the string parsing approach we started on Monday.

Now enums with any number of values and functions with any number of arguments can be registered.

Also, I had to remove GCC5 but added GCC9. (I hope that is ok)
`g++5` refused to compile my constexpr string comparison. See: https://travis-ci.org/arBmind/verdigris/jobs/608485170