### PR TITLE
Disable GCC from the cppapi unit test enum part.

### DIFF
--- a/tests/cppapi/tst_cppapi.cpp
+++ b/tests/cppapi/tst_cppapi.cpp
@@ -7,6 +7,10 @@ class tst_CppApi : public QObject
 {
     W_OBJECT(tst_CppApi)
 
+#if !defined(Q_CC_GNU) || defined(Q_CC_CLANG)
+    // GCC does not allow specialization
+    // see: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=85282
+
     enum class Level {
         Easy,
         Normal,
@@ -39,8 +43,6 @@ class tst_CppApi : public QObject
 private slots:
     void enumBase();
     W_SLOT(enumBase, W_Access::Private)
-
-#if !defined(Q_CC_GNU) || defined(Q_CC_CLANG) // GCC refuses to properly resolve registered signals for properties
 
     void firstTest();
     W_SLOT(firstTest, W_Access::Private)
@@ -179,10 +181,6 @@ void tst_CppApi::notifyTest()
     disconnect(conn0);
     disconnect(conn1);
 }
-#else // Q_CC_GNU
-};
-
-#endif
 
 void tst_CppApi::enumBase()
 {
@@ -191,6 +189,10 @@ void tst_CppApi::enumBase()
     QVERIFY(em.isValid());
     QCOMPARE(em.keyCount(), 3);
 }
+#else // Q_CC_GNU
+};
+
+#endif
 
 W_OBJECT_IMPL(tst_CppApi)
 


### PR DESCRIPTION
Turns out gcc has an unfixed issue since forever - https://gcc.gnu.org/bugzilla/show_bug.cgi?id=85282

Since C++17 it was defined that this should have worked since C++14.

The cpp tutorial uses real code and works with gcc. But I cannot make this unit test to work with gcc.
The unit test was not build for qmake so it did not come up on Travis.