### PR TITLE
register the object name for the cppapi tutorial

### DIFF
--- a/tutorial/cpp_tutorial.cpp
+++ b/tutorial/cpp_tutorial.cpp
@@ -136,6 +136,11 @@ W_OBJECT_IMPL(GenericPropertyHolder<Properties...>, template<class... Properties
 // For your person example you can now instanciate our template
 using PersonHolder = GenericPropertyHolder<Name, BirthYear>;
 
+constexpr auto w_explicitObjectName(PersonHolder*) {
+    return w_cpp::viewLiteral("PersonHolder");
+}
+
+
 // Implement a QML Quick application
 #include <QGuiApplication>
 #include <QQmlApplicationEngine>


### PR DESCRIPTION
It turns out the tutorial compiled fine, but did not run. I guess I had a patched Qt version.