### PR TITLE
Move possibly conflicting macros to separate file

### DIFF
--- a/src/wobjectdefs.h
+++ b/src/wobjectdefs.h
@@ -26,6 +26,7 @@
 
 #include <QtCore/qobjectdefs.h>
 #include <QtCore/qmetatype.h>
+
 #include <utility>
 
 #define W_VERSION 0x010200
@@ -883,33 +884,6 @@ struct InterfaceStateTag {};
                    w_internal::makeMetaConstructorInfo<__VA_ARGS__>(W_UnscopedName))
 
 
-/// \macro W_PROPERTY(<type>, <name> [, <flags>]*)
-///
-/// Declare a property <name> with the type <type>.
-/// The flags can be function pointers that are detected to be setter, getters, notify signal or
-/// other flags. Use the macro READ, WRITE, MEMBER, ... for the flag so you can write W_PROPERTY
-/// just like in a Q_PROPERTY. The only difference with Q_PROPERTY would be the semicolon before the
-/// name.
-/// W_PROPERTY need to be put after all the setters, getters, signals and members have been declared.
-///
-/// <type> can optionally be put in parentheses, if you have a type containing a comma
-#define W_PROPERTY(...) W_MACRO_MSVC_EXPAND(W_PROPERTY2(__VA_ARGS__)) // expands the READ, WRITE, and other sub marcos
-#define W_PROPERTY2(TYPE, NAME, ...) \
-    W_STATE_APPEND(PropertyState, \
-        w_internal::makeMetaPropertyInfo<W_MACRO_REMOVEPAREN(TYPE)>(\
-                            w_internal::viewLiteral(#NAME), w_internal::viewLiteral(W_MACRO_STRIGNIFY(W_MACRO_REMOVEPAREN(TYPE))), __VA_ARGS__))
-
-#define WRITE , &W_ThisType::
-#define READ , &W_ThisType::
-#define NOTIFY , W_Notify, &W_ThisType::
-#define RESET , W_Reset, &W_ThisType::
-#define MEMBER , &W_ThisType::
-#define CONSTANT , W_Constant
-#define FINAL , W_Final
-
-#undef Q_PRIVATE_PROPERTY // the official macro is not a variadic macro, and the coma in READ would break it
-#define Q_PRIVATE_PROPERTY(...)
-
 /// \macro W_ENUM(<name>, <values>)
 /// Similar to Q_ENUM, but one must also manually write all the values.
 #define W_ENUM(NAME, ...) \
@@ -981,7 +955,6 @@ W_REGISTER_ARGTYPE(const char*)
 // just to avoid parse errors when moc is run over things that it should ignore
 #define W_SIGNAL(...)        ;
 #define W_SIGNAL_COMPAT(...) ;
-#define W_PROPERTY(...)
 #define W_SLOT(...)
 #define W_CLASSINFO(...)
 #define W_INTERFACE(...)

--- a/src/wproperty.h
+++ b/src/wproperty.h
@@ -1,0 +1,56 @@
+/****************************************************************************
+ *  Copyright (C) 2016 - 2019 Woboq GmbH
+ *  Olivier Goffart <ogoffart at woboq.com>
+ *  https://woboq.com/
+ *
+ *  This file is part of Verdigris: a way to use Qt without moc.
+ *  https://github.com/woboq/verdigris
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this program.
+ *  If not, see <http://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+#ifndef Q_MOC_RUN // don't define anything when moc is run
+
+/// \macro W_PROPERTY(<type>, <name> [, <flags>]*)
+///
+/// Declare a property <name> with the type <type>.
+/// The flags can be function pointers that are detected to be setter, getters, notify signal or
+/// other flags. Use the macro READ, WRITE, MEMBER, ... for the flag so you can write W_PROPERTY
+/// just like in a Q_PROPERTY. The only difference with Q_PROPERTY would be the semicolon before the
+/// name.
+/// W_PROPERTY need to be put after all the setters, getters, signals and members have been declared.
+///
+/// <type> can optionally be put in parentheses, if you have a type containing a comma
+#define W_PROPERTY(...) W_MACRO_MSVC_EXPAND(W_PROPERTY2(__VA_ARGS__)) // expands the READ, WRITE, and other sub marcos
+#define W_PROPERTY2(TYPE, NAME, ...) \
+    W_STATE_APPEND(PropertyState, \
+        w_internal::makeMetaPropertyInfo<W_MACRO_REMOVEPAREN(TYPE)>(\
+                            w_internal::viewLiteral(#NAME), w_internal::viewLiteral(W_MACRO_STRIGNIFY(W_MACRO_REMOVEPAREN(TYPE))), __VA_ARGS__))
+
+#define WRITE , &W_ThisType::
+#define READ , &W_ThisType::
+#define NOTIFY , W_Notify, &W_ThisType::
+#define RESET , W_Reset, &W_ThisType::
+#define MEMBER , &W_ThisType::
+#define CONSTANT , W_Constant
+#define FINAL , W_Final
+
+#undef Q_PRIVATE_PROPERTY // the official macro is not a variadic macro, and the coma in READ would break it
+#define Q_PRIVATE_PROPERTY(...)
+
+#else // Q_MOC_RUN
+#define W_PROPERTY(...)
+#endif

--- a/tests/basic/anothertu.h
+++ b/tests/basic/anothertu.h
@@ -22,6 +22,7 @@
 
 #include <QObject>
 #include <wobjectimpl.h>
+#include <wproperty.h>
 
 namespace AnotherTU {
 struct Gaga {

--- a/tests/basic/tst_basic.cpp
+++ b/tests/basic/tst_basic.cpp
@@ -18,6 +18,7 @@
  *  If not, see <http://www.gnu.org/licenses/>.
  */
 #include <wobjectdefs.h>
+#include <wproperty.h>
 #include <QtCore/QObject>
 #include <QtCore/QMetaObject>
 

--- a/tests/cppapi/tst_cppapi.cpp
+++ b/tests/cppapi/tst_cppapi.cpp
@@ -1,5 +1,6 @@
 #include <wobjectcpp.h>
 #include <wobjectimpl.h>
+#include <wproperty.h>
 #include <QtCore/QMetaObject>
 #include <QtTest/QtTest>
 

--- a/tests/manyproperties/tst_manyproperties.cpp
+++ b/tests/manyproperties/tst_manyproperties.cpp
@@ -18,6 +18,7 @@
  *  If not, see <http://www.gnu.org/licenses/>.
  */
 #include <wobjectdefs.h>
+#include <wproperty.h>
 #include <QtTest/QtTest>
 
 class tst_ManyProperties : public QObject

--- a/tests/qt/qmetaobject/tst_qmetaobject.cpp
+++ b/tests/qt/qmetaobject/tst_qmetaobject.cpp
@@ -36,6 +36,7 @@
 #endif
 
 #include <wobjectimpl.h>
+#include <wproperty.h>
 
 Q_DECLARE_METATYPE(const QMetaObject *)
 

--- a/tests/qt/qmetaproperty/tst_qmetaproperty.cpp
+++ b/tests/qt/qmetaproperty/tst_qmetaproperty.cpp
@@ -33,6 +33,7 @@
 #include <qobject.h>
 #include <qmetaobject.h>
 #include <wobjectimpl.h>
+#include <wproperty.h>
 
 struct CustomType
 {

--- a/tests/qt/qobject/tst_qobject.cpp
+++ b/tests/qt/qobject/tst_qobject.cpp
@@ -51,6 +51,7 @@
 #include <math.h>
 
 #include <wobjectimpl.h>
+#include <wproperty.h>
 
 QT_WARNING_DISABLE_GCC("-Wdeprecated-declarations")
 QT_WARNING_DISABLE_CLANG("-Wdeprecated-declarations")

--- a/tests/templates/tst_templates.cpp
+++ b/tests/templates/tst_templates.cpp
@@ -18,6 +18,7 @@
  *  If not, see <http://www.gnu.org/licenses/>.
  */
 #include <wobjectdefs.h>
+#include <wproperty.h>
 #include <QtCore/QObject>
 class tst_Templates : public QObject
 {

--- a/tutorial/tutorial.cpp
+++ b/tutorial/tutorial.cpp
@@ -26,6 +26,7 @@
 // In a header file you would include the wobjectdefs.h header
 // This is equivalent to the qobjectdefs.h header
 #include <wobjectdefs.h>
+#include <wproperty.h>
 // And because you will inherit from QObject you also need to QObject header
 #include <QObject>
 


### PR DESCRIPTION
This moves the macro `W_PROPERTY` as well as its accompanying macros
`WRITE`, `READ`, `NOTIFY`, `RESET`, `MEMBER`, `CONSTANT`, and `FINAL`
to a separate file `wproperty.h`.

This is done because these macros tend to conflict with other code.
Separating them makes it possible to omit their definitions.

This is necessarily a breaking change as code using these macros will
now need to include `wproperty.h`.