### PR TITLE
Add support for MSVC in /Zc:preprocessor conformant mode

### DIFF
--- a/src/wobjectdefs.h
+++ b/src/wobjectdefs.h
@@ -584,6 +584,24 @@ template <typename... Args> constexpr QOverload<Args...> qOverload = {};
 } // namespace w_internal
 
 #if defined(Q_CC_MSVC) && !defined(Q_CC_CLANG)
+  #if _MSC_VER >= 1928
+    #if defined(_MSVC_TRADITIONAL) && _MSVC_TRADITIONAL
+      // MSVC in /Zc:preprocessor- mode (default)
+      #define W_CONFORMING_PREPROCESSOR 0
+    #else
+      // MSVC in /Zc:preprocessor mode
+      #define W_CONFORMING_PREPROCESSOR 1
+    #endif
+  #else
+    // Older versions of MSVC without the /Zc:preprocessor flag
+    #define W_CONFORMING_PREPROCESSOR 0
+  #endif
+#else
+  // Other compilers, generally conforming
+  #define W_CONFORMING_PREPROCESSOR 1
+#endif
+
+#if !W_CONFORMING_PREPROCESSOR
 // Workaround for MSVC: expension rules are different so we need some extra macro.
 #define W_MACRO_MSVC_EXPAND(...) __VA_ARGS__
 #define W_MACRO_MSVC_DELAY(X,...) W_MACRO_MSVC_EXPAND(X(__VA_ARGS__))


### PR DESCRIPTION
Title says it all, it seems to work fine in my version (cl.exe 19.28) - technically it should work back to cl.exe 16.5 but I think it'd be better for people who want to use on older msvc version to test it themselves in order to not break builds.

the MSVC flag is described here: https://docs.microsoft.com/en-us/cpp/preprocessor/preprocessor-experimental-overview?view=msvc-160 