### PR TITLE
MSVC 16.10 compatiblity

### DIFF
--- a/.github/workflows/clang.yml
+++ b/.github/workflows/clang.yml
@@ -72,18 +72,11 @@ jobs:
             qt_arch: gcc_64
             std_cpp: C++17
 
-          - host_system: ubuntu-16.04
-            clang_version: 8
+          - host_system: ubuntu-18.04
+            clang_version: 9
             qt_version: 5.12.3
             qt_arch: gcc_64
             std_cpp: C++14
-
-          # note: clang claims C++17 but std library is not ready!
-          # - host_system: ubuntu-16.04
-          #   clang_version: "6.0"
-          #   qt_version: 5.9.1
-          #   qt_arch: gcc_64
-          #   std_cpp: C++14
 
     runs-on: "${{ matrix.host_system }}"
     env:

--- a/.github/workflows/clang.yml
+++ b/.github/workflows/clang.yml
@@ -105,6 +105,8 @@ jobs:
 
       - name: Setup Clang
         run: |
+          sudo apt-get update
+          sudo apt-get install -y clang-${{ matrix.clang_version }}
           find /usr/bin -name "clang++*"
           echo $(which clang++)
           echo $(which clang++-${{ matrix.clang_version }})

--- a/.github/workflows/gcc.yml
+++ b/.github/workflows/gcc.yml
@@ -21,13 +21,7 @@ jobs:
             qt_arch: gcc_64
             std_cpp: C++17
 
-          - host_system: ubuntu-16.04
-            gcc_version: 8
-            qt_version: 5.12.3
-            qt_arch: gcc_64
-            std_cpp: C++14
-
-          - host_system: ubuntu-16.04
+          - host_system: ubuntu-18.04
             gcc_version: 7
             qt_version: 5.9.1
             qt_arch: gcc_64

--- a/.github/workflows/gcc.yml
+++ b/.github/workflows/gcc.yml
@@ -51,6 +51,8 @@ jobs:
 
       - name: Setup Gcc
         run: |
+          sudo apt-get update
+          sudo apt-get install -y g++-${{ matrix.gcc_version }}
           find /usr/bin -name "g++*"
           echo $(which g++)
           echo $(which g++-${{ matrix.gcc_version }})

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -72,17 +72,17 @@ jobs:
       matrix:
         include:
           - host_system: windows-2019
-            cl_version: "14.28"
+            cl_version: "14.29"
             qt_version: "6.0.0"
             qt_arch: win64_msvc2019_64
 
           - host_system: windows-2019
-            cl_version: "14.28"
+            cl_version: "14.29"
             qt_version: "5.15.2"
             qt_arch: win64_msvc2019_64
 
           - host_system: windows-2019
-            cl_version: "14.28"
+            cl_version: "14.29"
             qt_version: "5.12.9"
             qt_arch: win64_msvc2017_64
 

--- a/src/wobjectcpp.h
+++ b/src/wobjectcpp.h
@@ -67,7 +67,7 @@ namespace w_cpp {
 ///     constexpr char text[6] = "Hello"; // if you have a string literal use `viewLiteral` below.
 ///     constexpr auto view = w_cpp::StringView{&text[0], &text[5]};
 ///
-/// \note the end pointer has to point behind the \0
+/// \note the end pointer has to point behind the last character
 using w_internal::StringView;
 
 /// Array of StringView
@@ -120,8 +120,8 @@ constexpr auto makeProperty(StringView name, StringView type) {
 /// * .setIntegralConstant<T>() - set a compile time integral value type as a unique identifier
 /// * .build() - build the final MethodInfo for this signal
 template<typename F>
-constexpr auto makeSignalBuilder(StringView name, F func) {
-    return w_internal::MetaMethodInfoBuilder<F, W_MethodType::Signal.value>{name, func};
+constexpr auto makeSignalBuilder(StringView name, F func) -> w_internal::MetaMethodInfoBuilder<F, W_MethodType::Signal.value> {
+    return {name, func};
 }
 
 /// create a compile time enum description for registraton usage

--- a/verdigris.qbs
+++ b/verdigris.qbs
@@ -59,6 +59,9 @@ Project {
         name: "[Extra Files]"
         files: [
             ".appveyor.yml",
+            ".github/workflows/clang.yml",
+            ".github/workflows/gcc.yml",
+            ".github/workflows/windows.yml",
             ".travis.yml",
             "ChangeLog",
             "LICENSE.LGPLv3",

--- a/verdigris.qbs
+++ b/verdigris.qbs
@@ -29,7 +29,7 @@ Project {
             Properties {
                 condition: qbs.toolchain.contains('msvc')
                 cpp.cxxFlags: base.concat(
-                    "/permissive-", "/Zc:__cplusplus", // best C++ compatibility
+                    "/permissive-", "/Zc:__cplusplus", "/Zc:externConstexpr", "/Zc:inline", "/Zc:preprocessor", "/Zc:throwingNew", // best C++ compatibility
                     "/diagnostics:caret" // better errors
                 )
             }


### PR DESCRIPTION
MSVC 16.10 requires explicit return type for constexpr functions. Seems like a regression, but not very hard to fix for Verdigris.

This also updated Github Actions for GCC and Clang because versions <=8 were removed. See https://github.com/actions/virtual-environments/issues/2950
