### PR TITLE
Fixed C4189 warning on MSVC2022/Qt 6.3.1

### DIFF
--- a/src/wobjectimpl.h
+++ b/src/wobjectimpl.h
@@ -1153,7 +1153,8 @@ QT_WARNING_POP
     static void registerMethodArgumentType(int _id, void **_a) {
         if (_id == I) {
             using ObjI = typename T::W_MetaObjectCreatorHelper::ObjectInfo;
-            [[maybe_unused]] constexpr auto f = ObjI::method(index<I>).func;
+            constexpr auto f = ObjI::method(index<I>).func;
+            Q_UNUSED(f)
             using P = QtPrivate::FunctionPointer<std::remove_const_t<decltype(f)>>;
             auto _t = QtPrivate::ConnectionTypes<typename P::Arguments>::types();
             uint arg = *reinterpret_cast<uint*>(_a[1]);

--- a/src/wobjectimpl.h
+++ b/src/wobjectimpl.h
@@ -1153,7 +1153,7 @@ QT_WARNING_POP
     static void registerMethodArgumentType(int _id, void **_a) {
         if (_id == I) {
             using ObjI = typename T::W_MetaObjectCreatorHelper::ObjectInfo;
-            constexpr auto f = ObjI::method(index<I>).func;
+            [[maybe_unused]] constexpr auto f = ObjI::method(index<I>).func;
             using P = QtPrivate::FunctionPointer<std::remove_const_t<decltype(f)>>;
             auto _t = QtPrivate::ConnectionTypes<typename P::Arguments>::types();
             uint arg = *reinterpret_cast<uint*>(_a[1]);


### PR DESCRIPTION
Warning triggered on the latest version of MSVC2022 using Qt 6.3.1:

```
C:\Users\Jonathan\Desktop\verdigris\src\wobjectimpl.h(1156): warning C4189: 'f': local variable is initialized but not referenced
C:\Users\Jonathan\Desktop\verdigris\src\wobjectimpl.h(1224): note: see reference to function template instantiation 'void w_internal::FriendHelper::registerMethodArgumentType<WorkerThread<Model3DKey,Model3DCacheEntry,false,false>,0>(int,void **)' being compiled
C:\Users\Jonathan\Desktop\verdigris\src\wobjectimpl.h(1297): note: see reference to function template instantiation 'void w_internal::FriendHelper::qt_static_metacall_impl2<WorkerThread<Model3DKey,Model3DCacheEntry,false,false>,0,1,2,,>(QObject *,QMetaObject::Call,int,void **,std::integer_sequence<size_t,0,1,2>,std::integer_sequence<size_t>,std::integer_sequence<size_t>)' being compiled
C:\Users\Jonathan\Desktop\et319\modules\Kaos\KPluginCore\src\utils/workerthread.h(321): note: see reference to function template instantiation 'void w_internal::FriendHelper::qt_static_metacall_impl<WorkerThread<Model3DKey,Model3DCacheEntry,false,false>,QObject*&,QMetaObject::Call&,int&,void**&>(QObject *&,QMetaObject::Call &,int &,void **&)' being compiled
C:\Users\Jonathan\Desktop\et319\modules\Kaos\KPluginCore\src\utils/workerthread.h(321): note: while compiling class template member function 'void WorkerThread<Model3DKey,Model3DCacheEntry,false,false>::qt_static_metacall(QObject *,QMetaObject::Call,int,void **)'
C:\Users\Jonathan\Desktop\et319\modules\Kaos\KPluginCore\src\model3d\model3dcache.h(55): note: see reference to class template instantiation 'WorkerThread<Model3DKey,Model3DCacheEntry,false,false>' being compiled
```

Most-likely a compiler bug/false-positive I guess ?
I'm using a C++17 attribute here to mark the variable as maybe unused, if we wish to silence the warning on C++14 compilers I guess we could simply use a macro trick ?